### PR TITLE
Issue #684: ローカルAPIの画像のみグレースケール表示に修正

### DIFF
--- a/frontend/src/components/bases/Image/index.tsx
+++ b/frontend/src/components/bases/Image/index.tsx
@@ -18,6 +18,9 @@ export const Image = ({ src, alt }: Props) => {
         setIsLoading(true)
     }, [src])
 
+    // 一時的に開発環境ではグレースケール画像を表示
+    const isDevelopment = process.env.NODE_ENV === 'development'
+
     return (
         <div className={styles['container']}>
             <NextImage
@@ -32,7 +35,7 @@ export const Image = ({ src, alt }: Props) => {
                     setIsLoading(false)
                 }}
                 sizes="100%"
-                src={isLoading ? '/image/gray-image.png' : displaySrc}
+                src={isDevelopment || isLoading ? '/image/gray-image.png' : displaySrc}
             />
         </div>
     )

--- a/frontend/src/components/bases/Image/index.tsx
+++ b/frontend/src/components/bases/Image/index.tsx
@@ -18,8 +18,8 @@ export const Image = ({ src, alt }: Props) => {
         setIsLoading(true)
     }, [src])
 
-    // 一時的に開発環境ではグレースケール画像を表示
-    const isDevelopment = process.env.NODE_ENV === 'development'
+    // 一時的にローカルの画像APIではグレースケール画像を表示
+    const isLocalApi = process.env.NODE_ENV === 'development' && src.includes('http://localhost:8080/api/product_image')
 
     return (
         <div className={styles['container']}>
@@ -35,7 +35,7 @@ export const Image = ({ src, alt }: Props) => {
                     setIsLoading(false)
                 }}
                 sizes="100%"
-                src={isDevelopment || isLoading ? '/image/gray-image.png' : displaySrc}
+                src={isLocalApi || isLoading ? '/image/gray-image.png' : displaySrc}
             />
         </div>
     )


### PR DESCRIPTION
## Summary

- ローカルAPIの画像のみをグレースケール表示に限定
- 開発環境でのlocalhostの画像API（http://localhost:8080/api/product_image）のみを対象
- 画像ローディング中に加えて、ローカルAPIの画像も一時的にグレースケール表示
- 他の画像（CDN画像など）には影響しないよう改善

## Test plan

- [x] ローカルAPIの画像がグレースケール表示されることを確認
- [x] 他の画像（CDN画像など）が正常に表示されることを確認
- [x] 画像ローディング中のグレースケール表示確認
- [x] 本番環境での通常表示確認
- [x] 既存のテストが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)