### PR TITLE
Fixes #708: ClassificationListを分類ごとに3つに分ける

### DIFF
--- a/frontend/src/app/admin/classification/template/index.tsx
+++ b/frontend/src/app/admin/classification/template/index.tsx
@@ -37,24 +37,22 @@ export const ClassificationTemplate = ({ categories, targets, tags }: Props) => 
         },
     ]
 
-    const getCurrentItems = () => {
-        switch (activeTab) {
-            case ClassificationType.Category:
-                return categories
-            case ClassificationType.Target:
-                return targets
-            case ClassificationType.Tag:
-                return tags
-            default:
-                return []
-        }
-    }
-
     return (
         <div className={styles['classification-container']}>
             <Tab activeKey={activeTab} items={tabItems} onTabChange={setActiveTab} />
             <div className={styles['tab-content']}>
-                <ClassificationList items={getCurrentItems()} />
+                {(() => {
+                    switch (activeTab) {
+                        case ClassificationType.Category:
+                            return <ClassificationList items={categories} />
+                        case ClassificationType.Target:
+                            return <ClassificationList items={targets} />
+                        case ClassificationType.Tag:
+                            return <ClassificationList items={tags} />
+                        default:
+                            return null
+                    }
+                })()}
             </div>
         </div>
     )


### PR DESCRIPTION
## Summary

- .tab-content内でgetCurrentItems関数を削除し、即時関数のswitch文でClassificationListを3つ直接表示
- activeTabに応じてCategory、Target、Tag用のClassificationListを表示分け  
- プロパティを直接渡すことで、より明確な実装に変更

## Test plan

- [x] 分類管理ページでCategory、Target、Tagタブをそれぞれクリックして表示切り替えが正しく動作することを確認
- [x] 各タブで適切な分類リストが表示されることを確認
- [x] TypeScriptの型チェックが通ることを確認
- [x] eslintとprettierが通ることを確認
- [x] 全テストが通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)