### PR TITLE
Fixes #713: 分類のページの更新呼び出しを追加

### DIFF
--- a/frontend/src/apis/category.ts
+++ b/frontend/src/apis/category.ts
@@ -10,6 +10,11 @@ export interface IPostCategoryParams {
     form: IClassificationForm
 }
 
+export interface IPutCategoryParams {
+    form: IClassificationForm
+    id: number
+}
+
 export interface ICategoryResponse {
     message: string
 }
@@ -55,5 +60,28 @@ export const postCategory = async (params: IPostCategoryParams): Promise<ICatego
             throw error
         }
         throw new Error('カテゴリの追加に失敗しました')
+    }
+}
+
+/** カテゴリを更新 */
+export const putCategory = async (params: IPutCategoryParams): Promise<ICategoryResponse> => {
+    try {
+        const res = await fetch(`${process.env.API_URL}/category/${params.id}`, {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            credentials: 'include',
+            method: 'PUT',
+            body: JSON.stringify(params.form),
+        })
+
+        if (!res.ok) throw new ApiError(res)
+
+        return await res.json()
+    } catch (error) {
+        if (error instanceof ApiError) {
+            throw error
+        }
+        throw new Error('カテゴリの更新に失敗しました')
     }
 }

--- a/frontend/src/apis/category.ts
+++ b/frontend/src/apis/category.ts
@@ -12,7 +12,7 @@ export interface IPostCategoryParams {
 
 export interface IPutCategoryParams {
     form: IClassificationForm
-    id: number
+    uuid: string
 }
 
 export interface ICategoryResponse {
@@ -66,7 +66,7 @@ export const postCategory = async (params: IPostCategoryParams): Promise<ICatego
 /** カテゴリを更新 */
 export const putCategory = async (params: IPutCategoryParams): Promise<ICategoryResponse> => {
     try {
-        const res = await fetch(`${process.env.API_URL}/category/${params.id}`, {
+        const res = await fetch(`${process.env.API_URL}/category/${params.uuid}`, {
             headers: {
                 'Content-Type': 'application/json',
             },

--- a/frontend/src/apis/tag.ts
+++ b/frontend/src/apis/tag.ts
@@ -5,6 +5,11 @@ export interface IPostTagParams {
     form: IClassificationForm
 }
 
+export interface IPutTagParams {
+    form: IClassificationForm
+    uuid: string
+}
+
 export interface ITagResponse {
     message: string
 }
@@ -49,5 +54,28 @@ export const postTag = async (params: IPostTagParams): Promise<ITagResponse> => 
             throw error
         }
         throw new Error('タグの追加に失敗しました')
+    }
+}
+
+/** タグを更新 */
+export const putTag = async (params: IPutTagParams): Promise<ITagResponse> => {
+    try {
+        const res = await fetch(`${process.env.API_URL}/tag/${params.uuid}`, {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            credentials: 'include',
+            method: 'PUT',
+            body: JSON.stringify(params.form),
+        })
+
+        if (!res.ok) throw new ApiError(res)
+
+        return await res.json()
+    } catch (error) {
+        if (error instanceof ApiError) {
+            throw error
+        }
+        throw new Error('タグの更新に失敗しました')
     }
 }

--- a/frontend/src/apis/target.ts
+++ b/frontend/src/apis/target.ts
@@ -10,6 +10,11 @@ export interface IPostTargetParams {
     form: IClassificationForm
 }
 
+export interface IPutTargetParams {
+    form: IClassificationForm
+    uuid: string
+}
+
 export interface ITargetResponse {
     message: string
 }
@@ -55,5 +60,28 @@ export const postTarget = async (params: IPostTargetParams): Promise<ITargetResp
             throw error
         }
         throw new Error('ターゲットの追加に失敗しました')
+    }
+}
+
+/** ターゲットを更新 */
+export const putTarget = async (params: IPutTargetParams): Promise<ITargetResponse> => {
+    try {
+        const res = await fetch(`${process.env.API_URL}/target/${params.uuid}`, {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            credentials: 'include',
+            method: 'PUT',
+            body: JSON.stringify(params.form),
+        })
+
+        if (!res.ok) throw new ApiError(res)
+
+        return await res.json()
+    } catch (error) {
+        if (error instanceof ApiError) {
+            throw error
+        }
+        throw new Error('ターゲットの更新に失敗しました')
     }
 }


### PR DESCRIPTION
## Summary
- src/apis/category.ts に IPutCategoryParams インターフェースを新規追加
- putCategory 関数を実装してカテゴリの更新API処理を追加
- エラーハンドリングとTypeScript型安全性を確保
- 既存のPOST/GET処理と統一されたパターンで実装

## Test plan
- [ ] putCategory 関数の型定義が正しく機能することを確認
- [ ] API エンドポイント `/category/{id}` への PUT リクエストが正常に送信されることを確認
- [ ] エラーハンドリングが適切に動作することを確認
- [ ] 既存のカテゴリ取得・追加機能に影響がないことを確認
- [ ] TypeScript型チェックが通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)