### PR TITLE
Fixes #715: ClassificationListコンポーネントのカスタムフック作成

### DIFF
--- a/frontend/src/features/classification/components/ClassificationList/hooks/index.ts
+++ b/frontend/src/features/classification/components/ClassificationList/hooks/index.ts
@@ -1,0 +1,87 @@
+import { useState } from 'react'
+
+import { getCategories, postCategory } from '@/apis/category'
+import { getTags, postTag } from '@/apis/tag'
+import { getTargets, postTarget } from '@/apis/target'
+import { IClassification } from '@/features/classification/type'
+import { ClassificationType } from '@/types'
+
+import type { IClassificationForm } from '../../../type'
+
+interface UseClassificationListProps {
+    initialItems: IClassification[]
+    type: ClassificationType
+}
+
+export const useClassificationList = ({ initialItems, type }: UseClassificationListProps) => {
+    const [items, setItems] = useState<IClassification[]>(initialItems)
+    const [isOpen, setIsOpen] = useState<boolean>(false)
+    const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
+    const [submitError, setSubmitError] = useState<string | null>(null)
+
+    const handleOpenDialog = () => {
+        setIsOpen(true)
+        setSubmitError(null)
+    }
+
+    const handleCloseDialog = () => {
+        setIsOpen(false)
+        setSubmitError(null)
+    }
+
+    // typeに応じてAPIを切り替える関数
+    const postClassification = async (data: IClassificationForm) => {
+        switch (type) {
+            case ClassificationType.Category:
+                return await postCategory({ form: data })
+            case ClassificationType.Target:
+                return await postTarget({ form: data })
+            case ClassificationType.Tag:
+                return await postTag({ form: data })
+            default:
+                throw new Error('不正なタイプです')
+        }
+    }
+
+    const fetchClassifications = async (): Promise<IClassification[]> => {
+        switch (type) {
+            case ClassificationType.Category:
+                return await getCategories({ mode: 'all' })
+            case ClassificationType.Target:
+                return await getTargets({ mode: 'all' })
+            case ClassificationType.Tag:
+                return await getTags()
+            default:
+                throw new Error('不正なタイプです')
+        }
+    }
+
+    const handleFormSubmit = async (data: IClassificationForm) => {
+        try {
+            setIsSubmitting(true)
+            setSubmitError(null)
+
+            await postClassification(data)
+
+            // 追加成功後、一覧を再取得して状態を更新
+            const updatedItems = await fetchClassifications()
+            setItems(updatedItems)
+
+            handleCloseDialog()
+        } catch {
+            setSubmitError('送信中にエラーが発生しました。もう一度お試しください。')
+        } finally {
+            setIsSubmitting(false)
+        }
+    }
+
+    return {
+        items,
+        isOpen,
+        isSubmitting,
+        submitError,
+        handleOpenDialog,
+        handleCloseDialog,
+        handleFormSubmit,
+    }
+}

--- a/frontend/src/features/classification/components/ClassificationList/index.tsx
+++ b/frontend/src/features/classification/components/ClassificationList/index.tsx
@@ -1,20 +1,15 @@
 'use client'
 
 import { Add, Delete } from '@mui/icons-material'
-import { useState } from 'react'
 import { Virtuoso } from 'react-virtuoso'
 
-import { getCategories, postCategory } from '@/apis/category'
-import { getTags, postTag } from '@/apis/tag'
-import { getTargets, postTarget } from '@/apis/target'
 import { Button } from '@/components/bases/Button'
 import { IClassification } from '@/features/classification/type'
 import { ClassificationType } from '@/types'
 
 import { ClassificationFormDialog } from '../ClassificationFormDialog'
+import { useClassificationList } from './hooks'
 import styles from './styles.module.scss'
-
-import type { IClassificationForm } from '../../type'
 
 interface Props {
     initialItems: IClassification[]
@@ -22,66 +17,10 @@ interface Props {
 }
 
 export const ClassificationList = ({ initialItems, type }: Props) => {
-    const [items, setItems] = useState<IClassification[]>(initialItems)
-    const [isOpen, setIsOpen] = useState<boolean>(false)
-    const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
-    const [submitError, setSubmitError] = useState<string | null>(null)
-
-    const handleOpenDialog = () => {
-        setIsOpen(true)
-        setSubmitError(null)
-    }
-
-    const handleCloseDialog = () => {
-        setIsOpen(false)
-        setSubmitError(null)
-    }
-
-    // typeに応じてAPIを切り替える関数
-    const postClassification = async (data: IClassificationForm) => {
-        switch (type) {
-            case ClassificationType.Category:
-                return await postCategory({ form: data })
-            case ClassificationType.Target:
-                return await postTarget({ form: data })
-            case ClassificationType.Tag:
-                return await postTag({ form: data })
-            default:
-                throw new Error('不正なタイプです')
-        }
-    }
-
-    const fetchClassifications = async (): Promise<IClassification[]> => {
-        switch (type) {
-            case ClassificationType.Category:
-                return await getCategories({ mode: 'all' })
-            case ClassificationType.Target:
-                return await getTargets({ mode: 'all' })
-            case ClassificationType.Tag:
-                return await getTags()
-            default:
-                throw new Error('不正なタイプです')
-        }
-    }
-
-    const handleFormSubmit = async (data: IClassificationForm) => {
-        try {
-            setIsSubmitting(true)
-            setSubmitError(null)
-
-            await postClassification(data)
-
-            // 追加成功後、一覧を再取得して状態を更新
-            const updatedItems = await fetchClassifications()
-            setItems(updatedItems)
-
-            handleCloseDialog()
-        } catch {
-            setSubmitError('送信中にエラーが発生しました。もう一度お試しください。')
-        } finally {
-            setIsSubmitting(false)
-        }
-    }
+    const { items, isOpen, isSubmitting, submitError, handleOpenDialog, handleCloseDialog, handleFormSubmit } = useClassificationList({
+        initialItems,
+        type,
+    })
 
     return (
         <div className={styles['classification-list']}>


### PR DESCRIPTION
## Summary

- ClassificationListコンポーネントから状態管理とAPI呼び出しのロジックをカスタムフック（useClassificationList）に分離
- ClassificationListコンポーネントの可読性と保守性を向上
- 分類タイプに応じてAPI呼び出しを切り替える処理をフックに移行

## Test plan

- [x] Unit テストが正常に実行される
- [x] Integration テストが正常に実行される
- [x] Storybook テストが正常に実行される
- [x] ESLint・TypeScript チェックが通る
- [x] Storybook上での各分類タイプ（Category、Tag、Target）のClassificationListが正常に表示される
- [x] フォーム送信・ダイアログ開閉等の動作が正常に行われる

🤖 Generated with [Claude Code](https://claude.ai/code)