### PR TITLE
Fixes #717: 分類ページの編集機能を実装

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,16 +36,16 @@
         "@storybook/addon-themes": "^9.0.18",
         "@types/react-transition-group": "^4.4.12",
         "classnames": "^2.5.1",
-        "framer-motion": "^12.23.6",
+        "framer-motion": "^12.23.9",
         "http-status-codes": "^2.3.0",
         "next": "15.4.3",
         "react": "^19.1.0",
         "react-confetti": "^6.4.0",
         "react-dom": "^19.1.0",
-        "react-hook-form": "^7.60.0",
+        "react-hook-form": "^7.61.0",
         "react-transition-group": "^4.4.5",
         "react-virtuoso": "^4.13.0",
-        "zod": "^4.0.5"
+        "zod": "^4.0.8"
     },
     "devDependencies": {
         "@chromatic-com/storybook": "^4.0.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 5.2.6
       '@hookform/resolvers':
         specifier: ^5.1.1
-        version: 5.1.1(react-hook-form@7.60.0(react@19.1.0))
+        version: 5.1.1(react-hook-form@7.61.0(react@19.1.0))
       '@mui/icons-material':
         specifier: ^7.2.0
         version: 7.2.0(@mui/material@7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.8)(react@19.1.0)
@@ -39,8 +39,8 @@ importers:
         specifier: ^2.5.1
         version: 2.5.1
       framer-motion:
-        specifier: ^12.23.6
-        version: 12.23.6(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^12.23.9
+        version: 12.23.9(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       http-status-codes:
         specifier: ^2.3.0
         version: 2.3.0
@@ -57,8 +57,8 @@ importers:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
       react-hook-form:
-        specifier: ^7.60.0
-        version: 7.60.0(react@19.1.0)
+        specifier: ^7.61.0
+        version: 7.61.0(react@19.1.0)
       react-transition-group:
         specifier: ^4.4.5
         version: 4.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -66,8 +66,8 @@ importers:
         specifier: ^4.13.0
         version: 4.13.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       zod:
-        specifier: ^4.0.5
-        version: 4.0.5
+        specifier: ^4.0.8
+        version: 4.0.8
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^4.0.1
@@ -104,7 +104,7 @@ importers:
         version: 9.0.18(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(vitest@3.2.4)
       '@storybook/nextjs-vite':
         specifier: ^9.0.18
-        version: 9.0.18(@babel/core@7.28.0)(next@15.4.3(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.89.2))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.45.1)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(vite@7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))
+        version: 9.0.18(@babel/core@7.28.0)(next@15.4.3(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.89.2))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.45.1)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(vite@7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))
       '@storybook/react':
         specifier: ^9.0.18
         version: 9.0.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)
@@ -125,7 +125,7 @@ importers:
         version: 19.1.6(@types/react@19.1.8)
       '@vitest/browser':
         specifier: ^3.2.4
-        version: 3.2.4(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(playwright@1.54.1)(vite@7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))(vitest@3.2.4)
+        version: 3.2.4(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(playwright@1.54.1)(vite@7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(@vitest/browser@3.2.4)(vitest@3.2.4)
@@ -257,8 +257,8 @@ packages:
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.27.6':
-    resolution: {integrity: sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==}
+  '@babel/helpers@7.28.2':
+    resolution: {integrity: sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/parser@7.28.0':
@@ -266,8 +266,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/runtime@7.27.6':
-    resolution: {integrity: sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==}
+  '@babel/runtime@7.28.2':
+    resolution: {integrity: sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/template@7.27.2':
@@ -278,8 +278,8 @@ packages:
     resolution: {integrity: sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.28.1':
-    resolution: {integrity: sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==}
+  '@babel/types@7.28.2':
+    resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@1.0.2':
@@ -2114,8 +2114,8 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  electron-to-chromium@1.5.189:
-    resolution: {integrity: sha512-y9D1ntS1ruO/pZ/V2FtLE+JXLQe28XoRpZ7QCCo0T8LdQladzdcOVQZH/IWLVJvCw12OGMb6hYOeOAjntCmJRQ==}
+  electron-to-chromium@1.5.190:
+    resolution: {integrity: sha512-k4McmnB2091YIsdCgkS0fMVMPOJgxl93ltFzaryXqwip1AaxeDqKCGLxkXODDA5Ab/D+tV5EL5+aTx76RvLRxw==}
 
   emoji-regex@10.4.0:
     resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==}
@@ -2437,8 +2437,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  framer-motion@12.23.6:
-    resolution: {integrity: sha512-dsJ389QImVE3lQvM8Mnk99/j8tiZDM/7706PCqvkQ8sSCnpmWxsgX+g0lj7r5OBVL0U36pIecCTBoIWcM2RuKw==}
+  framer-motion@12.23.9:
+    resolution: {integrity: sha512-TqEHXj8LWfQSKqfdr5Y4mYltYLw96deu6/K9kGDd+ysqRJPNwF9nb5mZcrLmybHbU7gcJ+HQar41U3UTGanbbQ==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^18.0.0 || ^19.0.0
@@ -2918,8 +2918,8 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  loupe@3.1.4:
-    resolution: {integrity: sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==}
+  loupe@3.2.0:
+    resolution: {integrity: sha512-2NCfZcT5VGVNX9mSZIxLRkEAegDGBpuQZBy13desuHeVORmBDyAET4TkJr4SjqQy3A8JDofMN6LpkK8Xcm/dlw==}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -2989,8 +2989,8 @@ packages:
   module-alias@2.2.3:
     resolution: {integrity: sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q==}
 
-  motion-dom@12.23.6:
-    resolution: {integrity: sha512-G2w6Nw7ZOVSzcQmsdLc0doMe64O/Sbuc2bVAbgMz6oP/6/pRStKRiVRV4bQfHp5AHYAKEGhEdVHTM+R3FDgi5w==}
+  motion-dom@12.23.9:
+    resolution: {integrity: sha512-6Sv++iWS8XMFCgU1qwKj9l4xuC47Hp4+2jvPfyTXkqDg2tTzSgX6nWKD4kNFXk0k7llO59LZTPuJigza4A2K1A==}
 
   motion-utils@12.23.6:
     resolution: {integrity: sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==}
@@ -3278,8 +3278,8 @@ packages:
     peerDependencies:
       react: ^19.1.0
 
-  react-hook-form@7.60.0:
-    resolution: {integrity: sha512-SBrYOvMbDB7cV8ZfNpaiLcgjH/a1c7aK0lK+aNigpf4xWLO8q+o4tcvVurv3c4EOyzn/3dCsYt4GKD42VvJ/+A==}
+  react-hook-form@7.61.0:
+    resolution: {integrity: sha512-o8S/HcCeuaAQVib36fPCgOLaaQN/v7Anj8zlYjcLMcz+4FnNfMsoDAEvVCefLb3KDnS43wq3pwcifehhkwowuQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
@@ -3859,8 +3859,8 @@ packages:
       vite:
         optional: true
 
-  vite@7.0.5:
-    resolution: {integrity: sha512-1mncVwJxy2C9ThLwz0+2GKZyEXuC3MyWtAAlNftlZZXZDP3AJt5FmwcMit/IGGaNZ8ZOB2BNO/HFUB+CpN0NQw==}
+  vite@7.0.6:
+    resolution: {integrity: sha512-MHFiOENNBd+Bd9uvc8GEsIzdkn1JxMmEeYX35tI3fv0sJBUTfW5tQsoaOwuY4KhBI09A3dUJ/DXf2yxPVPUceg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -4069,8 +4069,8 @@ packages:
     resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
     engines: {node: '>=18'}
 
-  zod@4.0.5:
-    resolution: {integrity: sha512-/5UuuRPStvHXu7RS+gmvRf4NXrNxpSllGwDnCBcJZtQsKrviYXm54yDGV2KYNLT5kq0lHGcl7lqWJLgSaG+tgA==}
+  zod@4.0.8:
+    resolution: {integrity: sha512-+MSh9cZU9r3QKlHqrgHMTSr3QwMGv4PLfR0M4N/sYWV5/x67HgXEhIGObdBkpnX8G78pTgWnIrBL2lZcNJOtfg==}
 
 snapshots:
 
@@ -4104,11 +4104,11 @@ snapshots:
       '@babel/generator': 7.28.0
       '@babel/helper-compilation-targets': 7.27.2
       '@babel/helper-module-transforms': 7.27.3(@babel/core@7.28.0)
-      '@babel/helpers': 7.27.6
+      '@babel/helpers': 7.28.2
       '@babel/parser': 7.28.0
       '@babel/template': 7.27.2
       '@babel/traverse': 7.28.0
-      '@babel/types': 7.28.1
+      '@babel/types': 7.28.2
       convert-source-map: 2.0.0
       debug: 4.4.1
       gensync: 1.0.0-beta.2
@@ -4120,7 +4120,7 @@ snapshots:
   '@babel/generator@7.28.0':
     dependencies:
       '@babel/parser': 7.28.0
-      '@babel/types': 7.28.1
+      '@babel/types': 7.28.2
       '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
       jsesc: 3.1.0
@@ -4138,7 +4138,7 @@ snapshots:
   '@babel/helper-module-imports@7.27.1':
     dependencies:
       '@babel/traverse': 7.28.0
-      '@babel/types': 7.28.1
+      '@babel/types': 7.28.2
     transitivePeerDependencies:
       - supports-color
 
@@ -4157,22 +4157,22 @@ snapshots:
 
   '@babel/helper-validator-option@7.27.1': {}
 
-  '@babel/helpers@7.27.6':
+  '@babel/helpers@7.28.2':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.1
+      '@babel/types': 7.28.2
 
   '@babel/parser@7.28.0':
     dependencies:
-      '@babel/types': 7.28.1
+      '@babel/types': 7.28.2
 
-  '@babel/runtime@7.27.6': {}
+  '@babel/runtime@7.28.2': {}
 
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/parser': 7.28.0
-      '@babel/types': 7.28.1
+      '@babel/types': 7.28.2
 
   '@babel/traverse@7.28.0':
     dependencies:
@@ -4181,12 +4181,12 @@ snapshots:
       '@babel/helper-globals': 7.28.0
       '@babel/parser': 7.28.0
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.1
+      '@babel/types': 7.28.2
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/types@7.28.1':
+  '@babel/types@7.28.2':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
@@ -4257,7 +4257,7 @@ snapshots:
   '@emotion/babel-plugin@11.13.5':
     dependencies:
       '@babel/helper-module-imports': 7.27.1
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
       '@emotion/serialize': 1.3.3
@@ -4288,7 +4288,7 @@ snapshots:
 
   '@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
       '@emotion/babel-plugin': 11.13.5
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
@@ -4314,7 +4314,7 @@ snapshots:
 
   '@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
       '@emotion/babel-plugin': 11.13.5
       '@emotion/is-prop-valid': 1.3.1
       '@emotion/react': 11.14.0(@types/react@19.1.8)(react@19.1.0)
@@ -4465,10 +4465,10 @@ snapshots:
 
   '@fontsource/roboto@5.2.6': {}
 
-  '@hookform/resolvers@5.1.1(react-hook-form@7.60.0(react@19.1.0))':
+  '@hookform/resolvers@5.1.1(react-hook-form@7.61.0(react@19.1.0))':
     dependencies:
       '@standard-schema/utils': 0.3.0
-      react-hook-form: 7.60.0(react@19.1.0)
+      react-hook-form: 7.61.0(react@19.1.0)
 
   '@humanfs/core@0.19.1': {}
 
@@ -4606,12 +4606,12 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.8.3)(vite@7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.8.3)(vite@7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))':
     dependencies:
       glob: 10.4.5
       magic-string: 0.30.17
       react-docgen-typescript: 2.4.0(typescript@5.8.3)
-      vite: 7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0)
+      vite: 7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0)
     optionalDependencies:
       typescript: 5.8.3
 
@@ -4653,7 +4653,7 @@ snapshots:
 
   '@mui/icons-material@7.2.0(@mui/material@7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
       '@mui/material': 7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
     optionalDependencies:
@@ -4661,7 +4661,7 @@ snapshots:
 
   '@mui/material@7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
       '@mui/core-downloads-tracker': 7.2.0
       '@mui/system': 7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0)
       '@mui/types': 7.4.4(@types/react@19.1.8)
@@ -4682,7 +4682,7 @@ snapshots:
 
   '@mui/private-theming@7.2.0(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
       '@mui/utils': 7.2.0(@types/react@19.1.8)(react@19.1.0)
       prop-types: 15.8.1
       react: 19.1.0
@@ -4691,7 +4691,7 @@ snapshots:
 
   '@mui/styled-engine@7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
       '@emotion/sheet': 1.4.0
@@ -4704,7 +4704,7 @@ snapshots:
 
   '@mui/system@7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
       '@mui/private-theming': 7.2.0(@types/react@19.1.8)(react@19.1.0)
       '@mui/styled-engine': 7.2.0(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0))(@types/react@19.1.8)(react@19.1.0))(react@19.1.0)
       '@mui/types': 7.4.4(@types/react@19.1.8)
@@ -4720,13 +4720,13 @@ snapshots:
 
   '@mui/types@7.4.4(@types/react@19.1.8)':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
     optionalDependencies:
       '@types/react': 19.1.8
 
   '@mui/utils@7.2.0(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
       '@mui/types': 7.4.4(@types/react@19.1.8)
       '@types/prop-types': 15.7.15
       clsx: 2.1.1
@@ -4990,19 +4990,19 @@ snapshots:
       storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
       ts-dedent: 2.2.0
     optionalDependencies:
-      '@vitest/browser': 3.2.4(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(playwright@1.54.1)(vite@7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(playwright@1.54.1)(vite@7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))(vitest@3.2.4)
       '@vitest/runner': 3.2.4
       vitest: 3.2.4(@types/node@24.1.0)(@vitest/browser@3.2.4)(jiti@1.21.7)(jsdom@26.1.0)(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/builder-vite@9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(vite@7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))':
+  '@storybook/builder-vite@9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(vite@7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))':
     dependencies:
       '@storybook/csf-plugin': 9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))
       storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
       ts-dedent: 2.2.0
-      vite: 7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0)
+      vite: 7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0)
 
   '@storybook/csf-plugin@9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))':
     dependencies:
@@ -5016,18 +5016,18 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@storybook/nextjs-vite@9.0.18(@babel/core@7.28.0)(next@15.4.3(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.89.2))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.45.1)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(vite@7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))':
+  '@storybook/nextjs-vite@9.0.18(@babel/core@7.28.0)(next@15.4.3(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.89.2))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.45.1)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(vite@7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))':
     dependencies:
-      '@storybook/builder-vite': 9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(vite@7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))
+      '@storybook/builder-vite': 9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(vite@7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))
       '@storybook/react': 9.0.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)
-      '@storybook/react-vite': 9.0.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.45.1)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(vite@7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))
+      '@storybook/react-vite': 9.0.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.45.1)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(vite@7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))
       next: 15.4.3(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.89.2)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
       styled-jsx: 5.1.6(@babel/core@7.28.0)(react@19.1.0)
-      vite: 7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0)
-      vite-plugin-storybook-nextjs: 2.0.5(next@15.4.3(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.89.2))(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(vite@7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))
+      vite: 7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0)
+      vite-plugin-storybook-nextjs: 2.0.5(next@15.4.3(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.89.2))(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(vite@7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))
     optionalDependencies:
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -5042,11 +5042,11 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
 
-  '@storybook/react-vite@9.0.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.45.1)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(vite@7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))':
+  '@storybook/react-vite@9.0.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.45.1)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(vite@7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.8.3)(vite@7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.8.3)(vite@7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))
       '@rollup/pluginutils': 5.2.0(rollup@4.45.1)
-      '@storybook/builder-vite': 9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(vite@7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))
+      '@storybook/builder-vite': 9.0.18(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(vite@7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))
       '@storybook/react': 9.0.18(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)
       find-up: 7.0.0
       magic-string: 0.30.17
@@ -5056,7 +5056,7 @@ snapshots:
       resolve: 1.22.10
       storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
       tsconfig-paths: 4.2.0
-      vite: 7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0)
+      vite: 7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -5079,7 +5079,7 @@ snapshots:
   '@testing-library/dom@10.4.0':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       chalk: 4.1.2
@@ -5099,7 +5099,7 @@ snapshots:
 
   '@testing-library/react@16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
       '@testing-library/dom': 10.4.0
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
@@ -5121,23 +5121,23 @@ snapshots:
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.28.0
-      '@babel/types': 7.28.1
+      '@babel/types': 7.28.2
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.20.7
 
   '@types/babel__generator@7.27.0':
     dependencies:
-      '@babel/types': 7.28.1
+      '@babel/types': 7.28.2
 
   '@types/babel__template@7.4.4':
     dependencies:
       '@babel/parser': 7.28.0
-      '@babel/types': 7.28.1
+      '@babel/types': 7.28.2
 
   '@types/babel__traverse@7.20.7':
     dependencies:
-      '@babel/types': 7.28.1
+      '@babel/types': 7.28.2
 
   '@types/chai@5.2.2':
     dependencies:
@@ -5345,11 +5345,11 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitest/browser@3.2.4(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(playwright@1.54.1)(vite@7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))(vitest@3.2.4)':
+  '@vitest/browser@3.2.4(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(playwright@1.54.1)(vite@7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 3.2.4(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(vite@7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.4(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(vite@7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))
       '@vitest/utils': 3.2.4
       magic-string: 0.30.17
       sirv: 3.0.1
@@ -5381,7 +5381,7 @@ snapshots:
       tinyrainbow: 2.0.0
       vitest: 3.2.4(@types/node@24.1.0)(@vitest/browser@3.2.4)(jiti@1.21.7)(jsdom@26.1.0)(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0)
     optionalDependencies:
-      '@vitest/browser': 3.2.4(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(playwright@1.54.1)(vite@7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(playwright@1.54.1)(vite@7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))(vitest@3.2.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -5393,14 +5393,14 @@ snapshots:
       chai: 5.2.1
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(vite@7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))':
+  '@vitest/mocker@3.2.4(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(vite@7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.10.4(@types/node@24.1.0)(typescript@5.8.3)
-      vite: 7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0)
+      vite: 7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -5425,7 +5425,7 @@ snapshots:
   '@vitest/utils@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
-      loupe: 3.1.4
+      loupe: 3.2.0
       tinyrainbow: 2.0.0
 
   '@webassemblyjs/ast@1.14.1':
@@ -5664,7 +5664,7 @@ snapshots:
 
   babel-plugin-macros@3.1.0:
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
       cosmiconfig: 7.1.0
       resolve: 1.22.10
 
@@ -5690,7 +5690,7 @@ snapshots:
   browserslist@4.25.1:
     dependencies:
       caniuse-lite: 1.0.30001727
-      electron-to-chromium: 1.5.189
+      electron-to-chromium: 1.5.190
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.1)
 
@@ -5724,7 +5724,7 @@ snapshots:
       assertion-error: 2.0.1
       check-error: 2.1.1
       deep-eql: 5.0.2
-      loupe: 3.1.4
+      loupe: 3.2.0
       pathval: 2.0.1
 
   chalk@3.0.0:
@@ -5908,7 +5908,7 @@ snapshots:
 
   dom-helpers@5.2.1:
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
       csstype: 3.1.3
 
   dunder-proto@1.0.1:
@@ -5919,7 +5919,7 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  electron-to-chromium@1.5.189: {}
+  electron-to-chromium@1.5.190: {}
 
   emoji-regex@10.4.0: {}
 
@@ -6401,9 +6401,9 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  framer-motion@12.23.6(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  framer-motion@12.23.9(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
-      motion-dom: 12.23.6
+      motion-dom: 12.23.9
       motion-utils: 12.23.6
       tslib: 2.8.1
     optionalDependencies:
@@ -6899,7 +6899,7 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  loupe@3.1.4: {}
+  loupe@3.2.0: {}
 
   lru-cache@10.4.3: {}
 
@@ -6916,7 +6916,7 @@ snapshots:
   magicast@0.3.5:
     dependencies:
       '@babel/parser': 7.28.0
-      '@babel/types': 7.28.1
+      '@babel/types': 7.28.2
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
@@ -6958,7 +6958,7 @@ snapshots:
 
   module-alias@2.2.3: {}
 
-  motion-dom@12.23.6:
+  motion-dom@12.23.9:
     dependencies:
       motion-utils: 12.23.6
 
@@ -7239,7 +7239,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.0
       '@babel/traverse': 7.28.0
-      '@babel/types': 7.28.1
+      '@babel/types': 7.28.2
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.7
       '@types/doctrine': 0.0.9
@@ -7255,7 +7255,7 @@ snapshots:
       react: 19.1.0
       scheduler: 0.26.0
 
-  react-hook-form@7.60.0(react@19.1.0):
+  react-hook-form@7.61.0(react@19.1.0):
     dependencies:
       react: 19.1.0
 
@@ -7267,7 +7267,7 @@ snapshots:
 
   react-transition-group@4.4.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
-      '@babel/runtime': 7.27.6
+      '@babel/runtime': 7.28.2
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -7920,7 +7920,7 @@ snapshots:
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0)
+      vite: 7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -7935,7 +7935,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-storybook-nextjs@2.0.5(next@15.4.3(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.89.2))(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(vite@7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0)):
+  vite-plugin-storybook-nextjs@2.0.5(next@15.4.3(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.89.2))(storybook@9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2))(typescript@5.8.3)(vite@7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0)):
     dependencies:
       '@next/env': 15.4.3
       image-size: 2.0.2
@@ -7944,24 +7944,24 @@ snapshots:
       next: 15.4.3(@babel/core@7.28.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.89.2)
       storybook: 9.0.18(@testing-library/dom@10.4.0)(prettier@3.6.2)
       ts-dedent: 2.2.0
-      vite: 7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0)
-      vite-tsconfig-paths: 5.1.4(typescript@5.8.3)(vite@7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))
+      vite: 7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0)
+      vite-tsconfig-paths: 5.1.4(typescript@5.8.3)(vite@7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0)):
+  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0)):
     dependencies:
       debug: 4.4.1
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.8.3)
     optionalDependencies:
-      vite: 7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0)
+      vite: 7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0):
+  vite@7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.8
       fdir: 6.4.6(picomatch@4.0.3)
@@ -7981,7 +7981,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(vite@7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.4(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(vite@7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -7999,12 +7999,12 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0)
+      vite: 7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0)
       vite-node: 3.2.4(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.1.0
-      '@vitest/browser': 3.2.4(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(playwright@1.54.1)(vite@7.0.5(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(msw@2.10.4(@types/node@24.1.0)(typescript@5.8.3))(playwright@1.54.1)(vite@7.0.6(@types/node@24.1.0)(jiti@1.21.7)(sass@1.89.2)(terser@5.43.1)(yaml@2.8.0))(vitest@3.2.4)
       jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti
@@ -8186,4 +8186,4 @@ snapshots:
 
   yoctocolors-cjs@2.1.2: {}
 
-  zod@4.0.5: {}
+  zod@4.0.8: {}

--- a/frontend/src/app/admin/classification/template/index.tsx
+++ b/frontend/src/app/admin/classification/template/index.tsx
@@ -45,12 +45,22 @@ export const ClassificationTemplate = ({ categories, targets, tags }: Props) => 
                     switch (activeTab) {
                         case ClassificationType.Category:
                             return (
-                                <ClassificationList initialItems={categories} key={ClassificationType.Category} type={ClassificationType.Category} />
+                                <ClassificationList
+                                    classificationType={ClassificationType.Category}
+                                    initialItems={categories}
+                                    key={ClassificationType.Category}
+                                />
                             )
                         case ClassificationType.Target:
-                            return <ClassificationList initialItems={targets} key={ClassificationType.Target} type={ClassificationType.Target} />
+                            return (
+                                <ClassificationList
+                                    classificationType={ClassificationType.Target}
+                                    initialItems={targets}
+                                    key={ClassificationType.Target}
+                                />
+                            )
                         case ClassificationType.Tag:
-                            return <ClassificationList initialItems={tags} key={ClassificationType.Tag} type={ClassificationType.Tag} />
+                            return <ClassificationList classificationType={ClassificationType.Tag} initialItems={tags} key={ClassificationType.Tag} />
                         default:
                             return null
                     }

--- a/frontend/src/features/classification/components/ClassificationFormDialog/index.stories.tsx
+++ b/frontend/src/features/classification/components/ClassificationFormDialog/index.stories.tsx
@@ -17,7 +17,7 @@ const meta: Meta<typeof ClassificationFormDialog> = {
             await new Promise((resolve) => setTimeout(resolve, 1000))
         },
         submitError: null,
-        type: ClassificationType.Category,
+        classificationType: ClassificationType.Category,
     },
     argTypes: {
         isOpen: {
@@ -26,7 +26,7 @@ const meta: Meta<typeof ClassificationFormDialog> = {
         isSubmitting: {
             control: { type: 'boolean' },
         },
-        type: {
+        classificationType: {
             control: { type: 'select' },
             options: Object.values(ClassificationType),
         },
@@ -38,39 +38,39 @@ type Story = StoryObj<typeof ClassificationFormDialog>
 
 export const Category: Story = {
     args: {
-        type: ClassificationType.Category,
+        classificationType: ClassificationType.Category,
     },
 }
 
 export const Tag: Story = {
     args: {
-        type: ClassificationType.Tag,
+        classificationType: ClassificationType.Tag,
     },
 }
 
 export const Target: Story = {
     args: {
-        type: ClassificationType.Target,
+        classificationType: ClassificationType.Target,
     },
 }
 
 export const WithError: Story = {
     args: {
-        type: ClassificationType.Category,
+        classificationType: ClassificationType.Category,
         submitError: '送信中にエラーが発生しました。もう一度お試しください。',
     },
 }
 
 export const Submitting: Story = {
     args: {
-        type: ClassificationType.Category,
+        classificationType: ClassificationType.Category,
         isSubmitting: true,
     },
 }
 
 export const Closed: Story = {
     args: {
-        type: ClassificationType.Category,
+        classificationType: ClassificationType.Category,
         isOpen: false,
     },
 }

--- a/frontend/src/features/classification/components/ClassificationFormDialog/index.tsx
+++ b/frontend/src/features/classification/components/ClassificationFormDialog/index.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { zodResolver } from '@hookform/resolvers/zod'
+import { useEffect } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 
 import { Dialog } from '@/components/bases/Dialog'
@@ -11,7 +12,7 @@ import { ClassificationLabel, ClassificationType } from '@/types'
 
 import { ClassificationSchema } from '../../classification/schema'
 
-import type { IClassificationForm } from '../../type'
+import type { IClassification, IClassificationForm } from '../../type'
 
 interface Props {
     classificationType: ClassificationType
@@ -20,9 +21,10 @@ interface Props {
     onClose: () => void
     onSubmit: (_data: IClassificationForm) => Promise<void>
     submitError: string | null
+    updateItem: IClassification | null
 }
 
-export const ClassificationFormDialog = ({ isOpen, isSubmitting, onClose, onSubmit, submitError, classificationType }: Props) => {
+export const ClassificationFormDialog = ({ isOpen, isSubmitting, onClose, onSubmit, submitError, classificationType, updateItem }: Props) => {
     const {
         register,
         handleSubmit,
@@ -30,7 +32,19 @@ export const ClassificationFormDialog = ({ isOpen, isSubmitting, onClose, onSubm
         reset,
     } = useForm<IClassificationForm>({
         resolver: zodResolver(ClassificationSchema),
+        defaultValues: {
+            name: '',
+        },
     })
+
+    // updateItemが変更されたときにフォームをリセット
+    useEffect(() => {
+        if (isOpen) {
+            reset({
+                name: updateItem?.name || '',
+            })
+        }
+    }, [updateItem, isOpen, reset])
 
     const handleClose = () => {
         reset()
@@ -42,16 +56,18 @@ export const ClassificationFormDialog = ({ isOpen, isSubmitting, onClose, onSubm
         reset()
     }
 
+    const isEdit = updateItem !== null
+
     return (
         <Dialog
             confirmOption={{
-                label: isSubmitting ? '送信中...' : '追加',
+                label: isSubmitting ? '送信中...' : isEdit ? '更新' : '追加',
                 onClick: handleSubmit(handleFormSubmit),
                 disabled: isSubmitting,
             }}
             isOpen={isOpen}
             onClose={handleClose}
-            title={`${ClassificationLabel[classificationType]}を追加`}
+            title={`${ClassificationLabel[classificationType]}を${isEdit ? '編集' : '追加'}`}
             wide
         >
             {submitError && <Message type={MessageType.Error}>{submitError}</Message>}

--- a/frontend/src/features/classification/components/ClassificationFormDialog/index.tsx
+++ b/frontend/src/features/classification/components/ClassificationFormDialog/index.tsx
@@ -14,15 +14,15 @@ import { ClassificationSchema } from '../../classification/schema'
 import type { IClassificationForm } from '../../type'
 
 interface Props {
+    classificationType: ClassificationType
     isOpen: boolean
     isSubmitting: boolean
     onClose: () => void
     onSubmit: (_data: IClassificationForm) => Promise<void>
     submitError: string | null
-    type: ClassificationType
 }
 
-export const ClassificationFormDialog = ({ isOpen, isSubmitting, onClose, onSubmit, submitError, type }: Props) => {
+export const ClassificationFormDialog = ({ isOpen, isSubmitting, onClose, onSubmit, submitError, classificationType }: Props) => {
     const {
         register,
         handleSubmit,
@@ -51,7 +51,7 @@ export const ClassificationFormDialog = ({ isOpen, isSubmitting, onClose, onSubm
             }}
             isOpen={isOpen}
             onClose={handleClose}
-            title={`${ClassificationLabel[type]}を追加`}
+            title={`${ClassificationLabel[classificationType]}を追加`}
             wide
         >
             {submitError && <Message type={MessageType.Error}>{submitError}</Message>}
@@ -60,8 +60,8 @@ export const ClassificationFormDialog = ({ isOpen, isSubmitting, onClose, onSubm
                     {...register('name')}
                     error={errors.name?.message}
                     id="name"
-                    label={`${ClassificationLabel[type]}名`}
-                    placeholder={`テスト${ClassificationLabel[type]}`}
+                    label={`${ClassificationLabel[classificationType]}名`}
+                    placeholder={`テスト${ClassificationLabel[classificationType]}`}
                     required
                     type="text"
                 />

--- a/frontend/src/features/classification/components/ClassificationList/hooks/index.ts
+++ b/frontend/src/features/classification/components/ClassificationList/hooks/index.ts
@@ -1,8 +1,8 @@
 import { useState } from 'react'
 
-import { getCategories, postCategory } from '@/apis/category'
-import { getTags, postTag } from '@/apis/tag'
-import { getTargets, postTarget } from '@/apis/target'
+import { getCategories, postCategory, putCategory } from '@/apis/category'
+import { getTags, postTag, putTag } from '@/apis/tag'
+import { getTargets, postTarget, putTarget } from '@/apis/target'
 import { IClassification } from '@/features/classification/type'
 import { ClassificationType } from '@/types'
 
@@ -31,7 +31,7 @@ export const useClassificationList = ({ initialItems, classificationType }: UseC
         setSubmitError(null)
     }
 
-    // typeに応じてAPIを切り替える関数
+    // typeに応じてAPIを切り替える関数（追加）
     const postClassification = async (data: IClassificationForm) => {
         switch (classificationType) {
             case ClassificationType.Category:
@@ -40,6 +40,20 @@ export const useClassificationList = ({ initialItems, classificationType }: UseC
                 return await postTarget({ form: data })
             case ClassificationType.Tag:
                 return await postTag({ form: data })
+            default:
+                throw new Error('不正なタイプです')
+        }
+    }
+
+    // typeに応じてAPIを切り替える関数（更新）
+    const putClassification = async (data: IClassificationForm, uuid: string) => {
+        switch (classificationType) {
+            case ClassificationType.Category:
+                return await putCategory({ form: data, uuid })
+            case ClassificationType.Target:
+                return await putTarget({ form: data, uuid })
+            case ClassificationType.Tag:
+                return await putTag({ form: data, uuid })
             default:
                 throw new Error('不正なタイプです')
         }
@@ -63,9 +77,15 @@ export const useClassificationList = ({ initialItems, classificationType }: UseC
             setIsSubmitting(true)
             setSubmitError(null)
 
-            await postClassification(data)
+            if (updateItem) {
+                // 更新処理
+                await putClassification(data, updateItem.uuid)
+            } else {
+                // 追加処理
+                await postClassification(data)
+            }
 
-            // 追加成功後、一覧を再取得して状態を更新
+            // 成功後、一覧を再取得して状態を更新
             const updatedItems = await fetchClassifications()
             setItems(updatedItems)
 

--- a/frontend/src/features/classification/components/ClassificationList/hooks/index.ts
+++ b/frontend/src/features/classification/components/ClassificationList/hooks/index.ts
@@ -18,10 +18,12 @@ export const useClassificationList = ({ initialItems, classificationType }: UseC
     const [isOpen, setIsOpen] = useState<boolean>(false)
     const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
     const [submitError, setSubmitError] = useState<string | null>(null)
+    const [updateItem, setUpdateItem] = useState<IClassification | null>(null)
 
-    const handleOpenDialog = () => {
+    const handleOpenDialog = (item: IClassification | null) => {
         setIsOpen(true)
         setSubmitError(null)
+        setUpdateItem(item)
     }
 
     const handleCloseDialog = () => {
@@ -80,6 +82,7 @@ export const useClassificationList = ({ initialItems, classificationType }: UseC
         isOpen,
         isSubmitting,
         submitError,
+        updateItem,
         handleOpenDialog,
         handleCloseDialog,
         handleFormSubmit,

--- a/frontend/src/features/classification/components/ClassificationList/hooks/index.ts
+++ b/frontend/src/features/classification/components/ClassificationList/hooks/index.ts
@@ -9,11 +9,11 @@ import { ClassificationType } from '@/types'
 import type { IClassificationForm } from '../../../type'
 
 interface UseClassificationListProps {
+    classificationType: ClassificationType
     initialItems: IClassification[]
-    type: ClassificationType
 }
 
-export const useClassificationList = ({ initialItems, type }: UseClassificationListProps) => {
+export const useClassificationList = ({ initialItems, classificationType }: UseClassificationListProps) => {
     const [items, setItems] = useState<IClassification[]>(initialItems)
     const [isOpen, setIsOpen] = useState<boolean>(false)
     const [isSubmitting, setIsSubmitting] = useState<boolean>(false)
@@ -31,7 +31,7 @@ export const useClassificationList = ({ initialItems, type }: UseClassificationL
 
     // typeに応じてAPIを切り替える関数
     const postClassification = async (data: IClassificationForm) => {
-        switch (type) {
+        switch (classificationType) {
             case ClassificationType.Category:
                 return await postCategory({ form: data })
             case ClassificationType.Target:
@@ -44,7 +44,7 @@ export const useClassificationList = ({ initialItems, type }: UseClassificationL
     }
 
     const fetchClassifications = async (): Promise<IClassification[]> => {
-        switch (type) {
+        switch (classificationType) {
             case ClassificationType.Category:
                 return await getCategories({ mode: 'all' })
             case ClassificationType.Target:

--- a/frontend/src/features/classification/components/ClassificationList/index.stories.tsx
+++ b/frontend/src/features/classification/components/ClassificationList/index.stories.tsx
@@ -14,13 +14,13 @@ const meta: Meta<typeof ClassificationList> = {
             { uuid: '4', name: 'ブレスレット' },
             { uuid: '5', name: 'イヤリング' },
         ],
-        type: ClassificationType.Category,
+        classificationType: ClassificationType.Category,
     },
     argTypes: {
         initialItems: {
             description: '分類アイテムの配列',
         },
-        type: {
+        classificationType: {
             description: '分類の種類',
         },
     },

--- a/frontend/src/features/classification/components/ClassificationList/index.tsx
+++ b/frontend/src/features/classification/components/ClassificationList/index.tsx
@@ -32,7 +32,12 @@ export const ClassificationList = ({ initialItems, classificationType }: Props) 
                         computeItemKey={(_index, item) => item.uuid}
                         data={items}
                         itemContent={(_index, item) => (
-                            <div className={styles['list-item']} onClick={() => {}}>
+                            <div
+                                className={styles['list-item']}
+                                onClick={() => {
+                                    handleOpenDialog(item)
+                                }}
+                            >
                                 <div className={styles['item-content']}>
                                     <span className={styles['item-name']}>{item.name}</span>
                                     <div className={styles['item-actions']}>
@@ -50,7 +55,11 @@ export const ClassificationList = ({ initialItems, classificationType }: Props) 
                 )}
             </div>
             <div className={styles['add-button-container']}>
-                <Button onClick={handleOpenDialog}>
+                <Button
+                    onClick={() => {
+                        handleOpenDialog(null)
+                    }}
+                >
                     <div className={styles['add-button-content']}>
                         <Add className={styles['add-icon']} />
                         追加

--- a/frontend/src/features/classification/components/ClassificationList/index.tsx
+++ b/frontend/src/features/classification/components/ClassificationList/index.tsx
@@ -17,7 +17,7 @@ interface Props {
 }
 
 export const ClassificationList = ({ initialItems, classificationType }: Props) => {
-    const { items, isOpen, isSubmitting, submitError, handleOpenDialog, handleCloseDialog, handleFormSubmit } = useClassificationList({
+    const { items, isOpen, isSubmitting, submitError, updateItem, handleOpenDialog, handleCloseDialog, handleFormSubmit } = useClassificationList({
         initialItems,
         classificationType,
     })
@@ -73,6 +73,7 @@ export const ClassificationList = ({ initialItems, classificationType }: Props) 
                 onClose={handleCloseDialog}
                 onSubmit={handleFormSubmit}
                 submitError={submitError}
+                updateItem={updateItem}
             />
         </div>
     )

--- a/frontend/src/features/classification/components/ClassificationList/index.tsx
+++ b/frontend/src/features/classification/components/ClassificationList/index.tsx
@@ -12,14 +12,14 @@ import { useClassificationList } from './hooks'
 import styles from './styles.module.scss'
 
 interface Props {
+    classificationType: ClassificationType
     initialItems: IClassification[]
-    type: ClassificationType
 }
 
-export const ClassificationList = ({ initialItems, type }: Props) => {
+export const ClassificationList = ({ initialItems, classificationType }: Props) => {
     const { items, isOpen, isSubmitting, submitError, handleOpenDialog, handleCloseDialog, handleFormSubmit } = useClassificationList({
         initialItems,
-        type,
+        classificationType,
     })
 
     return (
@@ -58,12 +58,12 @@ export const ClassificationList = ({ initialItems, type }: Props) => {
                 </Button>
             </div>
             <ClassificationFormDialog
+                classificationType={classificationType}
                 isOpen={isOpen}
                 isSubmitting={isSubmitting}
                 onClose={handleCloseDialog}
                 onSubmit={handleFormSubmit}
                 submitError={submitError}
-                type={type}
             />
         </div>
     )


### PR DESCRIPTION
## Summary
- 分類ページ（Category、Target、Tag）に編集機能を実装
- 既存の追加機能を拡張し、編集モードでの動作を追加
- 各分類タイプに対応したPUT APIを使用した更新処理を実装

## Changes Made
### ClassificationFormDialog
- 編集モードでの初期値設定機能を追加
- ダイアログタイトルとボタンラベルの動的切り替え（「追加」/「編集」）
- useEffectを使用したフォームリセット処理の実装

### useClassificationList Hook
- PUT API関数の追加（putCategory、putTarget、putTag）
- 追加/更新の処理分岐ロジックを実装
- 更新後の一覧自動再取得機能

### ClassificationList Component
- 編集対象アイテム情報の適切な受け渡し
- updateItemプロパティの追加と連携

## Technical Details
- 分類タイプに応じた適切なAPI呼び出し（Category/Target/Tag）
- フォームの初期値設定とリセット処理
- 編集/追加モードの状態管理
- エラーハンドリングの維持

## Test plan
- [x] 各分類タイプ（Category、Target、Tag）での編集機能動作確認
- [x] フォーム初期値の正確な設定
- [x] 編集後の一覧更新確認
- [x] エラーハンドリングの動作確認
- [x] 既存の追加機能が正常に動作することを確認
- [x] 全テスト（Unit、Integration、Storybook）の通過確認

🤖 Generated with [Claude Code](https://claude.ai/code)