### PR TITLE
Fixes #720: 管理画面の分類ページに削除処理を追加

### DIFF
--- a/frontend/src/apis/category.ts
+++ b/frontend/src/apis/category.ts
@@ -15,6 +15,10 @@ export interface IPutCategoryParams {
     uuid: string
 }
 
+export interface IDeleteCategoryParams {
+    uuid: string
+}
+
 export interface ICategoryResponse {
     message: string
 }
@@ -83,5 +87,27 @@ export const putCategory = async (params: IPutCategoryParams): Promise<ICategory
             throw error
         }
         throw new Error('カテゴリの更新に失敗しました')
+    }
+}
+
+/** カテゴリを削除 */
+export const deleteCategory = async (params: IDeleteCategoryParams): Promise<ICategoryResponse> => {
+    try {
+        const res = await fetch(`${process.env.API_URL}/category/${params.uuid}`, {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            credentials: 'include',
+            method: 'DELETE',
+        })
+
+        if (!res.ok) throw new ApiError(res)
+
+        return await res.json()
+    } catch (error) {
+        if (error instanceof ApiError) {
+            throw error
+        }
+        throw new Error('カテゴリの削除に失敗しました')
     }
 }

--- a/frontend/src/apis/tag.ts
+++ b/frontend/src/apis/tag.ts
@@ -10,6 +10,10 @@ export interface IPutTagParams {
     uuid: string
 }
 
+export interface IDeleteTagParams {
+    uuid: string
+}
+
 export interface ITagResponse {
     message: string
 }
@@ -77,5 +81,27 @@ export const putTag = async (params: IPutTagParams): Promise<ITagResponse> => {
             throw error
         }
         throw new Error('タグの更新に失敗しました')
+    }
+}
+
+/** タグを削除 */
+export const deleteTag = async (params: IDeleteTagParams): Promise<ITagResponse> => {
+    try {
+        const res = await fetch(`${process.env.API_URL}/tag/${params.uuid}`, {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            credentials: 'include',
+            method: 'DELETE',
+        })
+
+        if (!res.ok) throw new ApiError(res)
+
+        return await res.json()
+    } catch (error) {
+        if (error instanceof ApiError) {
+            throw error
+        }
+        throw new Error('タグの削除に失敗しました')
     }
 }

--- a/frontend/src/apis/target.ts
+++ b/frontend/src/apis/target.ts
@@ -15,6 +15,10 @@ export interface IPutTargetParams {
     uuid: string
 }
 
+export interface IDeleteTargetParams {
+    uuid: string
+}
+
 export interface ITargetResponse {
     message: string
 }
@@ -83,5 +87,27 @@ export const putTarget = async (params: IPutTargetParams): Promise<ITargetRespon
             throw error
         }
         throw new Error('ターゲットの更新に失敗しました')
+    }
+}
+
+/** ターゲットを削除 */
+export const deleteTarget = async (params: IDeleteTargetParams): Promise<ITargetResponse> => {
+    try {
+        const res = await fetch(`${process.env.API_URL}/target/${params.uuid}`, {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            credentials: 'include',
+            method: 'DELETE',
+        })
+
+        if (!res.ok) throw new ApiError(res)
+
+        return await res.json()
+    } catch (error) {
+        if (error instanceof ApiError) {
+            throw error
+        }
+        throw new Error('ターゲットの削除に失敗しました')
     }
 }

--- a/frontend/src/features/classification/components/ClassificationList/index.tsx
+++ b/frontend/src/features/classification/components/ClassificationList/index.tsx
@@ -17,10 +17,11 @@ interface Props {
 }
 
 export const ClassificationList = ({ initialItems, classificationType }: Props) => {
-    const { items, isOpen, isSubmitting, submitError, updateItem, handleOpenDialog, handleCloseDialog, handleFormSubmit } = useClassificationList({
-        initialItems,
-        classificationType,
-    })
+    const { items, isOpen, isSubmitting, submitError, updateItem, isDeleting, handleOpenDialog, handleCloseDialog, handleFormSubmit, handleDelete } =
+        useClassificationList({
+            initialItems,
+            classificationType,
+        })
 
     return (
         <div className={styles['classification-list']}>
@@ -45,6 +46,11 @@ export const ClassificationList = ({ initialItems, classificationType }: Props) 
                                             className={styles['icon-button']}
                                             onClick={(e) => {
                                                 e.stopPropagation()
+                                                handleDelete(item)
+                                            }}
+                                            style={{
+                                                opacity: isDeleting ? 0.5 : 1,
+                                                pointerEvents: isDeleting ? 'none' : 'auto',
                                             }}
                                         />
                                     </div>

--- a/frontend/src/features/classification/components/ClassificationList/index.tsx
+++ b/frontend/src/features/classification/components/ClassificationList/index.tsx
@@ -4,8 +4,9 @@ import { Add, Delete } from '@mui/icons-material'
 import { Virtuoso } from 'react-virtuoso'
 
 import { Button } from '@/components/bases/Button'
+import { Dialog } from '@/components/bases/Dialog'
 import { IClassification } from '@/features/classification/type'
-import { ClassificationType } from '@/types'
+import { ClassificationLabel, ClassificationType } from '@/types'
 
 import { ClassificationFormDialog } from '../ClassificationFormDialog'
 import { useClassificationList } from './hooks'
@@ -17,11 +18,25 @@ interface Props {
 }
 
 export const ClassificationList = ({ initialItems, classificationType }: Props) => {
-    const { items, isOpen, isSubmitting, submitError, updateItem, isDeleting, handleOpenDialog, handleCloseDialog, handleFormSubmit, handleDelete } =
-        useClassificationList({
-            initialItems,
-            classificationType,
-        })
+    const {
+        items,
+        isOpen,
+        isSubmitting,
+        submitError,
+        targetItem,
+        isDeleteDialogOpen,
+        handleOpenDialog,
+        handleCloseDialog,
+        handleFormSubmit,
+        handleOpenDeleteDialog,
+        handleCloseDeleteDialog,
+        handleConfirmDelete,
+    } = useClassificationList({
+        initialItems,
+        classificationType,
+    })
+
+    const classificationName = ClassificationLabel[classificationType]
 
     return (
         <div className={styles['classification-list']}>
@@ -46,11 +61,7 @@ export const ClassificationList = ({ initialItems, classificationType }: Props) 
                                             className={styles['icon-button']}
                                             onClick={(e) => {
                                                 e.stopPropagation()
-                                                handleDelete(item)
-                                            }}
-                                            style={{
-                                                opacity: isDeleting ? 0.5 : 1,
-                                                pointerEvents: isDeleting ? 'none' : 'auto',
+                                                handleOpenDeleteDialog(item)
                                             }}
                                         />
                                     </div>
@@ -79,8 +90,30 @@ export const ClassificationList = ({ initialItems, classificationType }: Props) 
                 onClose={handleCloseDialog}
                 onSubmit={handleFormSubmit}
                 submitError={submitError}
-                updateItem={updateItem}
+                updateItem={targetItem}
             />
+            <Dialog
+                cancelOption={{
+                    label: 'キャンセル',
+                    onClick: handleCloseDeleteDialog,
+                }}
+                confirmOption={{
+                    label: '削除',
+                    onClick: handleConfirmDelete,
+                }}
+                isOpen={isDeleteDialogOpen}
+                onClose={handleCloseDeleteDialog}
+                title="削除確認"
+            >
+                {targetItem && (
+                    <>
+                        <p>
+                            {classificationName}「{targetItem.name}」を削除しますか？
+                        </p>
+                        <p>この操作は取り消せません。</p>
+                    </>
+                )}
+            </Dialog>
         </div>
     )
 }


### PR DESCRIPTION
## Summary
- apis配下にカテゴリー、ターゲット、タグの削除用API処理を追加
- ClassificationListコンポーネントの削除アイコンに削除処理を実装
- 削除確認をDialogコンポーネントで表示するように実装
- 削除完了時にトースト通知と一覧自動更新を実装

## Test plan
- [x] 分類管理画面で削除アイコンをクリックすると削除確認ダイアログが表示される
- [x] 削除確認ダイアログの「キャンセル」ボタンでダイアログが閉じられる
- [x] 削除確認ダイアログの「削除」ボタンで削除処理が実行される
- [x] 削除完了時にトースト通知が表示される
- [x] 削除後に一覧が自動更新される
- [x] カテゴリー、ターゲット、タグの各種類で削除処理が動作する
- [x] リンターとテストが全て通過する

## 実装詳細
1. **API削除処理の追加**
   - `src/apis/category.ts`に`deleteCategory`関数を追加
   - `src/apis/target.ts`に`deleteTarget`関数を追加
   - `src/apis/tag.ts`に`deleteTag`関数を追加

2. **削除確認ダイアログの実装**
   - `window.confirm`ではなく、既存のDialogコンポーネントを使用
   - `targetItem`として編集・削除で同じ状態を共有
   - `isDeleteDialogOpen`で削除ダイアログの開閉を管理

3. **削除処理のハンドラー実装**
   - `handleOpenDeleteDialog`で削除確認ダイアログを表示
   - `handleConfirmDelete`で実際の削除処理を実行
   - 削除完了時にトースト通知と一覧更新を実行

🤖 Generated with [Claude Code](https://claude.ai/code)