### PR TITLE
Issue #739: 商品作成、更新、削除系のAPI呼び出し処理を追加

### DIFF
--- a/frontend/src/apis/product.ts
+++ b/frontend/src/apis/product.ts
@@ -2,14 +2,14 @@ import { IProduct, IProductsByCategory, IThumbnail } from '@/features/product/ty
 import { ApiError } from '@/utils/error'
 import { convertObjectToURLSearchParams } from '@/utils/request'
 
-export interface IGetProductsByCategoryParams {
+export interface IGetProductsParams {
     category: 'all' | string
     mode: 'all' | 'active'
     target: 'all' | string
 }
 
 /** カテゴリーごとの商品リストを取得 */
-export const getProductsByCategory = async (params: IGetProductsByCategoryParams): Promise<IProductsByCategory[]> => {
+export const getProductsByCategory = async (params: IGetProductsParams): Promise<IProductsByCategory[]> => {
     try {
         const query = convertObjectToURLSearchParams(params)
         const res = await fetch(`${process.env.API_URL}/category/product?${query}`, {
@@ -74,16 +74,6 @@ export const getCarouselImages = async (): Promise<IThumbnail[]> => {
 export interface IProductImageParams {
     isChanged: boolean
     order: { [key: number]: number }
-}
-
-export interface IGetProductsParams {
-    category: 'all' | string
-    mode: 'all' | 'active'
-    target: 'all' | string
-}
-
-export interface ICreemaDuplicateParams {
-    url: string
 }
 
 /** 商品リストを取得（管理画面用） */
@@ -197,6 +187,10 @@ export const uploadProductImages = async (productUuid: string, files: File[], or
         }
         throw new Error('商品画像のアップロードに失敗しました')
     }
+}
+
+export interface ICreemaDuplicateParams {
+    url: string
 }
 
 /** Creemaから商品を複製 */

--- a/frontend/src/apis/product.ts
+++ b/frontend/src/apis/product.ts
@@ -70,3 +70,152 @@ export const getCarouselImages = async (): Promise<IThumbnail[]> => {
         throw new Error('カルーセル画像の取得に失敗しました')
     }
 }
+
+export interface IProductImageParams {
+    isChanged: boolean
+    order: { [key: number]: number }
+}
+
+export interface IGetProductsParams {
+    category: 'all' | string
+    mode: 'all' | 'active'
+    target: 'all' | string
+}
+
+export interface ICreemaDuplicateParams {
+    url: string
+}
+
+/** 商品リストを取得（管理画面用） */
+export const getProducts = async (params: IGetProductsParams): Promise<IProduct[]> => {
+    try {
+        const query = convertObjectToURLSearchParams(params)
+        const res = await fetch(`${process.env.API_URL}/product?${query}`, {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            method: 'GET',
+        })
+
+        if (!res.ok) throw new ApiError(res)
+
+        return await res.json()
+    } catch (error) {
+        if (error instanceof ApiError) {
+            throw error
+        }
+        throw new Error('商品リストの取得に失敗しました')
+    }
+}
+
+/** 商品を作成 */
+export const createProduct = async (product: Omit<IProduct, 'uuid'>): Promise<IProduct> => {
+    try {
+        const res = await fetch(`${process.env.API_URL}/product`, {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            method: 'POST',
+            body: JSON.stringify(product),
+            credentials: 'include',
+        })
+
+        if (!res.ok) throw new ApiError(res)
+
+        return await res.json()
+    } catch (error) {
+        if (error instanceof ApiError) {
+            throw error
+        }
+        throw new Error('商品の作成に失敗しました')
+    }
+}
+
+/** 商品を更新 */
+export const updateProduct = async (uuid: string, product: IProduct): Promise<IProduct> => {
+    try {
+        const res = await fetch(`${process.env.API_URL}/product/${uuid}`, {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            method: 'PUT',
+            body: JSON.stringify(product),
+            credentials: 'include',
+        })
+
+        if (!res.ok) throw new ApiError(res)
+
+        return await res.json()
+    } catch (error) {
+        if (error instanceof ApiError) {
+            throw error
+        }
+        throw new Error('商品の更新に失敗しました')
+    }
+}
+
+/** 商品を削除 */
+export const deleteProduct = async (uuid: string): Promise<void> => {
+    try {
+        const res = await fetch(`${process.env.API_URL}/product/${uuid}`, {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            method: 'DELETE',
+            credentials: 'include',
+        })
+
+        if (!res.ok) throw new ApiError(res)
+    } catch (error) {
+        if (error instanceof ApiError) {
+            throw error
+        }
+        throw new Error('商品の削除に失敗しました')
+    }
+}
+
+/** 商品画像をアップロード */
+export const uploadProductImages = async (productUuid: string, files: File[], orderParams: IProductImageParams): Promise<void> => {
+    try {
+        const formData = new FormData()
+        formData.append('order', JSON.stringify(orderParams))
+
+        files.forEach((file, index) => {
+            formData.append(`file${index}`, file)
+        })
+
+        const res = await fetch(`${process.env.API_URL}/product/${productUuid}/product_image`, {
+            method: 'POST',
+            body: formData,
+            credentials: 'include',
+        })
+
+        if (!res.ok) throw new ApiError(res)
+    } catch (error) {
+        if (error instanceof ApiError) {
+            throw error
+        }
+        throw new Error('商品画像のアップロードに失敗しました')
+    }
+}
+
+/** Creemaから商品を複製 */
+export const duplicateProductFromCreema = async (params: ICreemaDuplicateParams): Promise<void> => {
+    try {
+        const res = await fetch(`${process.env.API_URL}/product/duplicate`, {
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            method: 'POST',
+            body: JSON.stringify(params),
+            credentials: 'include',
+        })
+
+        if (!res.ok) throw new ApiError(res)
+    } catch (error) {
+        if (error instanceof ApiError) {
+            throw error
+        }
+        throw new Error('Creemaからの商品複製に失敗しました')
+    }
+}


### PR DESCRIPTION
## Summary

- frontend/src/apis/product.ts に商品管理用API関数を追加
- client/app/pages/admin/product/ 配下の既存実装を参考に型安全なAPI関数として実装
- TypeScript型チェックとESLintチェック済み

## 実装内容

### 追加されたAPI関数

1. **getProducts**: 管理画面用の商品リスト取得
   - カテゴリ、モード、ターゲットによるフィルタリング対応
   - クエリパラメータの自動変換

2. **createProduct**: 商品作成
   - Omit<IProduct, 'uuid'>型で必要なフィールドのみを要求
   - 認証情報を含むcredentials設定

3. **updateProduct**: 商品更新
   - UUIDと完全な商品データを受け取り
   - PUT リクエストによる更新

4. **deleteProduct**: 商品削除
   - UUIDによる商品削除
   - レスポンスボディなしのvoid型

5. **uploadProductImages**: 商品画像アップロード
   - FormDataによるマルチパートアップロード
   - 画像順序管理とファイル複数アップロード対応

6. **duplicateProductFromCreema**: Creemaからの商品複製
   - URLを指定してCreemaから商品情報を取得・複製

### 型定義

- **IProductImageParams**: 画像アップロード時の順序管理用
- **IGetProductsParams**: 商品リスト取得時のフィルタパラメータ
- **ICreemaDuplicateParams**: Creema複製用のURL指定

## Test plan

- [x] TypeScript型チェック (`pnpm tsc`) - エラーなし
- [x] ESLintチェック (`pnpm lint`) - 警告ゼロ
- [x] 全テスト実行 (`pnpm test-all`) - 全て通過
- [x] コードフォーマット (`pnpm fmt`) - 適用済み
- [x] 既存実装との整合性確認
- [ ] 管理画面での実際の動作確認（次回実装時）
- [ ] APIエンドポイントとの疎通確認（バックエンド連携時）

🤖 Generated with [Claude Code](https://claude.ai/code)