### PR TITLE
Fixes #749: 商品登録、更新ページの販売サイトの表示を変更する

### DIFF
--- a/frontend/src/components/bases/ImagePreviewList/styles.module.scss
+++ b/frontend/src/components/bases/ImagePreviewList/styles.module.scss
@@ -16,7 +16,7 @@
     max-height: 300px;
     overflow-y: auto;
     padding: 8px;
-    border: 1px solid $light-dark-color;
+    border: 1px dashed $light-dark-color;
     border-radius: 8px;
     background-color: $primary-bg-color;
 

--- a/frontend/src/features/product/components/ProductFormDialog/styles.module.scss
+++ b/frontend/src/features/product/components/ProductFormDialog/styles.module.scss
@@ -19,6 +19,15 @@
     color: $title-primary-color;
 }
 
+.registered-sites-label {
+    display: block;
+    font-size: $font-medium;
+    font-weight: 600;
+    margin-top: 1rem;
+    margin-bottom: 0.5rem;
+    color: $title-primary-color;
+}
+
 .price-row {
     display: flex;
     align-items: flex-end;
@@ -109,14 +118,26 @@
 }
 
 .site-detail-input {
+    width: 100%;
+    margin-bottom: 1rem;
+}
+
+.url-input-row {
     display: flex;
     gap: 0.75rem;
-    margin-bottom: 1rem;
+    margin-top: 1rem;
+    align-items: flex-start;
 
     @include media('sm') {
         flex-direction: column;
         gap: 0.5rem;
     }
+}
+
+.url-input-wrapper {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
 }
 
 .url-input {
@@ -140,6 +161,15 @@
     &::placeholder {
         color: $text-color;
     }
+
+    &.error {
+        border-color: $danger-color;
+
+        &:focus {
+            border-color: $danger-color;
+            box-shadow: 0 0 0 2px color.adjust($danger-color, $alpha: -0.8);
+        }
+    }
 }
 
 .site-detail-list {
@@ -149,48 +179,53 @@
     padding: 0.75rem;
     border: 1px dashed $light-dark-color;
     border-radius: 0.375rem;
-    background-color: $secondary-bg-color;
+    background-color: $primary-bg-color;
 }
 
-.site-detail-item {
+.selected-chip-container {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.5rem 0.75rem;
-    background-color: $primary-bg-color;
-    border: 1px solid $light-dark-color;
-    border-radius: 0.375rem;
+    position: relative;
+
+    // Chipコンポーネント内での配置を調整
+    span {
+        display: inline-flex;
+        align-items: center;
+    }
 }
 
-.site-detail-link {
-    color: $primary;
+.chip-link {
+    color: inherit;
     text-decoration: none;
-    font-size: $font-medium;
-    font-weight: 500;
 
     &:hover {
         text-decoration: underline;
     }
 }
 
-.remove-button {
-    background: none;
-    border: none;
-    color: $danger-color;
-    cursor: pointer;
-    font-size: 1rem;
-    font-weight: bold;
-    padding: 0;
-    width: 1.25rem;
-    height: 1.25rem;
-    display: flex;
+.chip-close-button {
+    display: inline-flex;
     align-items: center;
     justify-content: center;
+    width: 1rem;
+    height: 1rem;
+    background: none;
+    border: none;
+    color: #ffffff;
+    cursor: pointer;
     border-radius: 50%;
-    transition: $transition;
+    margin-left: 0.25rem;
+    transition: color 0.3s ease;
+    vertical-align: middle;
+    align-self: center;
+
+    svg {
+        width: 0.75rem;
+        height: 0.75rem;
+    }
 
     &:hover {
-        background-color: $danger-bg-color;
+        color: #ff6b6b;
     }
 }
 
@@ -200,4 +235,11 @@
     font-weight: 600;
     color: $title-primary-color;
     padding: 0.5rem 0;
+}
+
+.field-error {
+    display: block;
+    color: $danger-color;
+    font-size: $font-sm-md;
+    margin-top: 0.25rem;
 }


### PR DESCRIPTION
## Summary
- **販売サイト選択の横幅拡張**: SelectFormをダイアログの横幅いっぱいに広げました
- **条件付きURL入力表示**: URLの入力画面は販売サイトの選択があるときだけ表示されるようにしました  
- **URLを追加ボタンの配置**: URLの右隣に「URLを追加ボタン」を配置しました
- **Chipコンポーネントによる販売サイト表示**: 下の販売サイト名の表示にChipコンポーネントを使用しました

## UI/UXの改善

### MultiSelectFormとの見た目統一
MultiSelectFormの選択時の見た目と配色・クローズアイコンを合わせました：
- Chipの配色: `ColorType.Secondary`（`#bcaaa4`）、白文字
- クローズアイコン: Material-UIの`Close`アイコンを使用
- ホバー時の色変更: `#ff6b6b`

### デザインの統一
- **背景色の統一**: 販売サイト登録結果部分の背景色を白色に統一しました
- **ラベルの追加**: 登録済み販売サイトの上に「現在の登録」ラベルを追加しました
- **枠線の統一**: 商品画像と販売サイトの「現在の登録」部分の枠線を破線で統一し、プレビュー表示であることを明確にしました

## バリデーション機能の追加
URL追加部分に販売サイトの登録と同じレベルのバリデーションを追加：
- **URL形式チェック**: JavaScriptのURLコンストラクタを使用したURL形式の検証
- **重複チェック**: 同じサイトで既に登録済みのURLかどうかをチェック
- **リアルタイムバリデーション**: 入力時にエラーメッセージを表示
- **エラー時のボタン無効化**: バリデーションエラー時の視覚的フィードバック

## 変更されたファイル
- `frontend/src/features/product/components/ProductFormDialog/index.tsx`
- `frontend/src/features/product/components/ProductFormDialog/styles.module.scss`
- `frontend/src/components/bases/ImagePreviewList/styles.module.scss`

## デザイン方針
既存のダイアログのデザインと統一感を保ちながら、MultiSelectFormコンポーネントの選択時の見た目と同じスタイルを適用することで、UI全体の一貫性を向上させました。また、プレビュー表示であることを明確にするため、破線の枠線を使用してユーザビリティを向上させました。

## Test plan
- [ ] 販売サイト選択フォームの横幅がダイアログ全体に広がっていることを確認
- [ ] 販売サイト未選択時にURL入力フィールドが非表示になることを確認
- [ ] 販売サイト選択後にURL入力フィールドとボタンが表示されることを確認
- [ ] URLバリデーション（形式チェック）が正常に動作することを確認
- [ ] 重複URL登録時のバリデーションが正常に動作することを確認
- [ ] 登録済み販売サイトがChipコンポーネントで表示されることを確認
- [ ] Chipのクローズボタンで販売サイトが削除できることを確認
- [ ] MultiSelectFormと同じスタイル（色、アイコン）が適用されていることを確認
- [ ] 枠線が破線になり、プレビュー表示であることが分かりやすいことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)