### PR TITLE
Fixes #751: 商品一覧のカード全体を編集画面への遷移にする

### DIFF
--- a/frontend/src/features/product/components/ProductCard/index.tsx
+++ b/frontend/src/features/product/components/ProductCard/index.tsx
@@ -1,4 +1,4 @@
-import { Delete, Edit } from '@mui/icons-material'
+import { Delete } from '@mui/icons-material'
 
 import { Chip, ChipSize } from '@/components/bases/Chip'
 import { Image } from '@/components/bases/Image'
@@ -28,6 +28,7 @@ export const ProductCard = ({ product, onEdit, onDelete, admin = false }: Props)
             className={`${styles['product-card']} ${product.isActive ? styles['is-active'] : ''} ${
                 product.isActive && product.isRecommend ? styles['is-recommend'] : ''
             }`}
+            onClick={admin ? handleEdit : undefined}
         >
             <div className={styles['product-card-wrapper']}>
                 <div className={styles['product-card-header']}>
@@ -70,10 +71,13 @@ export const ProductCard = ({ product, onEdit, onDelete, admin = false }: Props)
                     <div className={styles['product-card-footer-content']}>
                         {admin && (
                             <div className={styles['admin-actions']}>
-                                <button className={styles['edit-button']} onClick={handleEdit}>
-                                    <Edit sx={{ fontSize: 16 }} />
-                                </button>
-                                <button className={styles['delete-button']} onClick={handleDelete}>
+                                <button
+                                    className={styles['delete-button']}
+                                    onClick={(e) => {
+                                        e.stopPropagation()
+                                        handleDelete()
+                                    }}
+                                >
                                     <Delete sx={{ fontSize: 16 }} />
                                 </button>
                             </div>


### PR DESCRIPTION
## Summary

商品一覧画面のProductCardコンポーネントにおいて、UXを向上させるためにカード全体を編集画面への遷移に変更しました。

## 主な変更内容

### 1. Editアイコンボタンの削除
- `Edit`アイコンのインポートを削除
- 管理者モードでのEditボタンを完全に削除

### 2. カード全体をクリック可能に変更
- `<article>`要素に`onClick={admin ? handleEdit : undefined}`を追加
- 管理者モードの場合のみ、カード全体クリックで編集画面に遷移
- カスタマーモードでは従来通りの動作を維持

### 3. Deleteボタンのイベント伝播防止
- Deleteボタンに`stopPropagation`を追加
- `onClick={(e) => { e.stopPropagation(); handleDelete() }}`でカードクリックイベントとの競合を防止

## Test plan

- [x] 管理者モードでカード全体クリック時に編集画面に正しく遷移することを確認
- [x] カスタマーモードではカードクリックが無効であることを確認
- [x] Deleteボタンクリック時にカード全体のクリックイベントが発生しないことを確認
- [x] 既存のStorybookテストが正常に動作することを確認
- [x] リンティング・TypeScriptチェックが通過することを確認

## 期待される効果

- より直感的なUI操作によるユーザビリティの向上
- カード全体が編集領域として機能するため、より大きなクリック領域を提供
- Editボタンの削除により、よりすっきりとしたインターフェース

🤖 Generated with [Claude Code](https://claude.ai/code)