### PR TITLE
Fixes #753: creemaからの複製フォームを作成する

### DIFF
--- a/frontend/src/app/admin/product/template/index.tsx
+++ b/frontend/src/app/admin/product/template/index.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
 import { getCategories } from '@/apis/category'
-import { createProduct, deleteProduct, getProducts, updateProduct, uploadProductImage } from '@/apis/product'
+import { createProduct, deleteProduct, duplicateProductFromCreema, getProducts, updateProduct, uploadProductImage } from '@/apis/product'
 import { getSalesSiteList } from '@/apis/salesSite'
 import { getTags } from '@/apis/tag'
 import { getTargets } from '@/apis/target'
@@ -14,6 +14,7 @@ import { Dialog } from '@/components/bases/Dialog'
 import { IClassification } from '@/features/classification/type'
 import { ProductCard } from '@/features/product/components/ProductCard'
 import { ProductFormDialog } from '@/features/product/components/ProductFormDialog'
+import { ICreemaDuplicateForm } from '@/features/product/product/type'
 import { IProduct, IProductForm } from '@/features/product/type'
 import { ISite } from '@/features/site/type'
 
@@ -233,6 +234,26 @@ export const AdminProductTemplate = () => {
         }
     }
 
+    const handleCreemaDuplicate = async (data: ICreemaDuplicateForm) => {
+        try {
+            setIsSubmitting(true)
+            setSubmitError(null)
+
+            await duplicateProductFromCreema({ url: data.creemaUrl })
+
+            setIsDialogOpen(false)
+            toast.success('Creemaから商品を複製しました')
+            await fetchData()
+        } catch (error) {
+            console.error('Creemaからの商品複製に失敗しました:', error)
+            const errorMessage = 'Creemaからの商品複製に失敗しました。もう一度お試しください。'
+            setSubmitError(errorMessage)
+            toast.error(errorMessage)
+        } finally {
+            setIsSubmitting(false)
+        }
+    }
+
     return (
         <div className={styles['product-container']}>
             <div className={styles['page-header']}>
@@ -270,6 +291,7 @@ export const AdminProductTemplate = () => {
                 isOpen={isDialogOpen}
                 isSubmitting={isSubmitting}
                 onClose={handleCloseDialog}
+                onCreemaDuplicate={handleCreemaDuplicate}
                 onSubmit={handleSubmit}
                 salesSites={salesSites}
                 submitError={submitError}

--- a/frontend/src/features/product/components/ProductFormDialog/index.stories.tsx
+++ b/frontend/src/features/product/components/ProductFormDialog/index.stories.tsx
@@ -33,6 +33,10 @@ const meta: Meta<typeof ProductFormDialog> = {
             console.log('フォーム送信:', data)
             await new Promise((resolve) => setTimeout(resolve, 1000))
         },
+        onCreemaDuplicate: async (data) => {
+            console.log('Creema複製:', data)
+            await new Promise((resolve) => setTimeout(resolve, 1000))
+        },
         submitError: null,
         updateItem: null,
     },

--- a/frontend/src/features/product/product/schema.ts
+++ b/frontend/src/features/product/product/schema.ts
@@ -14,11 +14,41 @@ export const ProductSchema = z.object({
         .array(
             z.object({
                 salesSiteUuid: z.string(),
-                detailUrl: z.string().url('正しいURLを入力してください'),
+                detailUrl: z.string().refine(
+                    (url) => {
+                        try {
+                            new URL(url)
+                            return true
+                        } catch {
+                            return false
+                        }
+                    },
+                    { message: '正しいURLを入力してください' },
+                ),
             }),
         )
         .optional(),
     uploadImages: z.array(z.instanceof(File)).optional(),
     imageItems: z.array(z.any()).optional(), // ImageItem型 - zodでは複雑な型の検証を簡略化
     isImageOrderChanged: z.boolean().optional(),
+})
+
+/** Creema複製フォームのバリデーションスキーマ */
+export const CreemaDuplicateSchema = z.object({
+    creemaUrl: z
+        .string()
+        .min(1, 'URLは必須項目です')
+        .refine(
+            (url) => {
+                try {
+                    new URL(url)
+                    return url.includes('creema')
+                } catch {
+                    return false
+                }
+            },
+            {
+                message: 'CreemaのURLを入力してください',
+            },
+        ),
 })

--- a/frontend/src/features/product/product/type.ts
+++ b/frontend/src/features/product/product/type.ts
@@ -1,6 +1,9 @@
 import z from 'zod'
 
-import { ProductSchema } from './schema'
+import { CreemaDuplicateSchema, ProductSchema } from './schema'
 
 /** 商品フォームのデータ型 */
 export type IProductForm = z.infer<typeof ProductSchema>
+
+/** Creema複製フォームのデータ型 */
+export type ICreemaDuplicateForm = z.infer<typeof CreemaDuplicateSchema>


### PR DESCRIPTION
## Summary

Issue #753に対応して、ProductFormDialogにCreema複製機能を実装しました。

- 新規商品作成時にCreema複製か手動入力かを選択可能
- Creema複製時は専用のフォーム（URLのみ）を表示
- 手動入力時は従来のフルフォームを表示
- ZodバリデーションによるURL検証を実装
- 商品名の文字数制限を255文字に変更

## 主な変更点

### フロントエンド (Next.js)
- `ProductFormDialog`にCreema複製機能を追加
- `CreemaDuplicateSchema`でZodバリデーション実装
- 新規作成時のモード選択UI追加（デフォルトはCreema複製）
- 商品名フィールドの文字数制限を255文字に変更
- Storybook対応も実装

### APIインターフェース
- 既存の`duplicateProductFromCreema` APIを活用
- フォーム送信後にトーストメッセージでフィードバック

## Test plan

- [ ] 商品管理画面で「追加」ボタンをクリック
- [ ] デフォルトで「Creemaから複製」が選択されていることを確認
- [ ] CreemaのURLを入力してフォーム送信が正常に動作することを確認
- [ ] 「手動で入力」を選択して従来のフォームが表示されることを確認
- [ ] バリデーションエラーが適切に表示されることを確認
- [ ] 商品名が255文字まで入力できることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)