### PR TITLE
Fixes #758: GTMの設定を追加する

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -27,6 +27,7 @@ const nextConfig: NextConfig = {
     env: {
         API_BASE_URL: process.env.API_BASE_URL ? process.env.API_BASE_URL : 'http://localhost:8080/api',
         DOMAIN_URL: process.env.DOMAIN_URL ? process.env.DOMAIN_URL : `http://localhost:${process.env.PORT ? process.env.PORT : '3000'}`,
+        GOOGLE_TAG: process.env.GOOGLE_TAG,
     },
 }
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
         "@hookform/resolvers": "^5.2.1",
         "@mui/icons-material": "^7.3.1",
         "@mui/material": "^7.3.1",
+        "@next/third-parties": "^15.4.6",
         "@storybook/addon-styling-webpack": "^2.0.0",
         "@storybook/addon-themes": "^9.1.2",
         "@types/react-transition-group": "^4.4.12",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@mui/material':
         specifier: ^7.3.1
         version: 7.3.1(@emotion/react@11.14.0(@types/react@19.1.10)(react@19.1.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.1.10)(react@19.1.1))(@types/react@19.1.10)(react@19.1.1))(@types/react@19.1.10)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@next/third-parties':
+        specifier: ^15.4.6
+        version: 15.4.6(next@15.4.6(@babel/core@7.28.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.90.0))(react@19.1.1)
       '@storybook/addon-styling-webpack':
         specifier: ^2.0.0
         version: 2.0.0(storybook@9.1.2(@testing-library/dom@10.4.1)(msw@2.10.5(@types/node@24.3.0)(typescript@5.9.2))(prettier@3.6.2)(vite@7.1.2(@types/node@24.3.0)(jiti@1.21.7)(sass@1.90.0)(terser@5.43.1)(yaml@2.8.1)))(webpack@5.100.1(esbuild@0.25.9))
@@ -978,6 +981,12 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@next/third-parties@15.4.6':
+    resolution: {integrity: sha512-1BVymp3iVCMKvfIAlU1yptJuVnwiiyOs852WqPmj8bHPK7dcJN7vGEvH2uIKy9yBOi2UXZevlRT5njPDLZDHYg==}
+    peerDependencies:
+      next: ^13.0.0 || ^14.0.0 || ^15.0.0
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -3698,6 +3707,9 @@ packages:
     resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
     engines: {node: '>=18'}
 
+  third-party-capital@1.0.20:
+    resolution: {integrity: sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==}
+
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -4791,6 +4803,12 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@15.4.6':
     optional: true
+
+  '@next/third-parties@15.4.6(next@15.4.6(@babel/core@7.28.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.90.0))(react@19.1.1)':
+    dependencies:
+      next: 15.4.6(@babel/core@7.28.3)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(sass@1.90.0)
+      react: 19.1.1
+      third-party-capital: 1.0.20
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -7764,6 +7782,8 @@ snapshots:
       '@istanbuljs/schema': 0.1.3
       glob: 10.4.5
       minimatch: 9.0.5
+
+  third-party-capital@1.0.20: {}
 
   tiny-invariant@1.3.3: {}
 

--- a/frontend/src/app/(contents)/layout.tsx
+++ b/frontend/src/app/(contents)/layout.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { GoogleAnalytics } from '@next/third-parties/google'
 import classNames from 'classnames'
 import { usePathname } from 'next/navigation'
 
@@ -28,6 +29,7 @@ const DetailsLayout = ({ children }: { children: React.ReactNode }) => {
                 </PageFadeTransition>
             </main>
             <Footer />
+            {process.env.GOOGLE_TAG && <GoogleAnalytics gaId={process.env.GOOGLE_TAG} />}
         </div>
     )
 }

--- a/frontend/src/app/(home)/layout.tsx
+++ b/frontend/src/app/(home)/layout.tsx
@@ -1,5 +1,7 @@
 import 'ress'
 
+import { GoogleAnalytics } from '@next/third-parties/google'
+
 import { Footer } from '@/components/layouts/Footer'
 import { Header } from '@/components/layouts/Header'
 
@@ -9,6 +11,7 @@ const HomeLayout = ({ children }: { children: React.ReactNode }) => {
             <Header />
             <main>{children}</main>
             <Footer />
+            {process.env.GOOGLE_TAG && <GoogleAnalytics gaId={process.env.GOOGLE_TAG} />}
         </div>
     )
 }


### PR DESCRIPTION
## Summary
- @next/third-partiesパッケージを追加してGoogle Tag Manager（GTM）の設定を実装
- Next.js 15のApp Router公式推奨方法でGTM対応を実装
- 環境変数GOOGLE_TAGによる条件付きでGoogleAnalyticsコンポーネントを配置

## Test plan
- [x] 依存関係のインストールが正常に完了することを確認
- [x] next.config.tsでGOOGLE_TAG環境変数が正しく設定されることを確認
- [x] (home)/layout.tsxと(contents)/layout.tsxにGoogleAnalyticsコンポーネントが適切に配置されることを確認
- [x] GOOGLE_TAG環境変数が設定されていない場合はコンポーネントが表示されないことを確認
- [x] テストスイートが全て通ることを確認
- [x] TypeScript型チェックが通ることを確認
- [x] リントエラーがないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)