### PR TITLE
Issue #767: ShareButtonsコンポーネントに共有機能を追加

### DIFF
--- a/frontend/src/components/composites/ShareButtons/index.stories.tsx
+++ b/frontend/src/components/composites/ShareButtons/index.stories.tsx
@@ -9,9 +9,24 @@ const meta: Meta<typeof ShareButtons> = {
             appDirectory: true,
         },
     },
+    args: {
+        url: '',
+    },
+    argTypes: {
+        url: {
+            control: { type: 'text' },
+            description: '共有するURL（指定しない場合は現在のページのURLを使用）',
+        },
+    },
 }
 
 export default meta
 type Story = StoryObj<typeof ShareButtons>
 
 export const Default: Story = {}
+
+export const WithCustomUrl: Story = {
+    args: {
+        url: 'https://tocoriri.com/product/123',
+    },
+}

--- a/frontend/src/components/composites/ShareButtons/index.tsx
+++ b/frontend/src/components/composites/ShareButtons/index.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import { Facebook, Reply, X } from '@mui/icons-material'
 
 import { Icon } from '@/components/bases/Icon'
@@ -5,7 +7,34 @@ import { ColorType } from '@/types'
 
 import styles from './styles.module.scss'
 
-export const ShareButtons = () => {
+interface Props {
+    url?: string
+}
+
+export const ShareButtons = ({ url }: Props) => {
+    const getShareUrl = (): string => {
+        if (url) {
+            return url
+        }
+        // クライアントサイドでのみ実行
+        if (typeof window !== 'undefined') {
+            return window.location.href
+        }
+        return ''
+    }
+
+    const shareUrl = getShareUrl()
+
+    const handleXShare = () => {
+        const xShareUrl = `https://twitter.com/share?url=${encodeURIComponent(shareUrl)}`
+        window.open(xShareUrl, '_blank', 'nofollow')
+    }
+
+    const handleFacebookShare = () => {
+        const facebookShareUrl = `https://www.facebook.com/share.php?u=${encodeURIComponent(shareUrl)}`
+        window.open(facebookShareUrl, '_blank', 'nofollow,noopener')
+    }
+
     return (
         <div className={styles['container']}>
             <div className={styles['message']}>
@@ -16,14 +45,18 @@ export const ShareButtons = () => {
             </div>
             <div className={styles['icon-area']}>
                 <div>
-                    <Icon color={ColorType.Primary} contrast shadow={false} size={40}>
-                        <X />
-                    </Icon>
+                    <button aria-label="X(Twitter)でシェア" className={styles['share-button']} onClick={handleXShare} type="button">
+                        <Icon color={ColorType.Primary} contrast shadow={false} size={40}>
+                            <X />
+                        </Icon>
+                    </button>
                 </div>
                 <div>
-                    <Icon color={ColorType.Primary} contrast shadow={false} size={40}>
-                        <Facebook />
-                    </Icon>
+                    <button aria-label="Facebookでシェア" className={styles['share-button']} onClick={handleFacebookShare} type="button">
+                        <Icon color={ColorType.Primary} contrast shadow={false} size={40}>
+                            <Facebook />
+                        </Icon>
+                    </button>
                 </div>
             </div>
         </div>

--- a/frontend/src/components/composites/ShareButtons/styles.module.scss
+++ b/frontend/src/components/composites/ShareButtons/styles.module.scss
@@ -22,4 +22,22 @@
         align-items: center;
         gap: 24px;
     }
+
+    .share-button {
+        background: none;
+        border: none;
+        cursor: pointer;
+        padding: 0;
+        transition: transform 0.2s ease;
+
+        &:hover {
+            transform: scale(1.1);
+        }
+
+        &:focus {
+            outline: 2px solid $primary;
+            outline-offset: 2px;
+            border-radius: 4px;
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- X(Twitter)とFacebookの共有ボタンにクリックイベントを実装し、実際の共有機能を追加
- URLパラメータを受け取る機能を追加（未指定時は現在ページのURLを使用）
- 'use client'ディレクティブを追加してクライアントコンポーネントとして動作するよう修正
- ボタンのホバー効果とフォーカス時のアクセシビリティを向上
- ESLintルールに準拠した属性順序に修正
- Storybookに新しいPropsに対応したストーリーを追加

## 修正内容詳細

### 1. 共有機能の実装
- `handleXShare()`: X(Twitter)での共有機能を実装
- `handleFacebookShare()`: Facebookでの共有機能を実装  
- `window.open()`を使用して新しいタブで共有画面を開く設定

### 2. URL指定機能の追加
- `url?: string`プロパティを追加
- `getShareUrl()`関数で現在のページURLまたは指定されたURLを取得
- クライアントサイドでの`window.location.href`取得に対応

### 3. クライアントコンポーネント化
- `'use client'`ディレクティブを追加
- ブラウザAPIを使用するため必要な対応

### 4. アクセシビリティとUIの向上
- `aria-label`でスクリーンリーダー対応
- ホバー時の拡大効果（`transform: scale(1.1)`）
- フォーカス時のアウトライン表示
- `nofollow`, `noopener`属性でセキュリティ強化

### 5. Storybookの拡充
- `WithCustomUrl`ストーリーを追加
- URLプロパティの制御とドキュメントを追加

## Test plan
- [x] ShareButtonsコンポーネントのStorybookが正常に表示されることを確認
- [x] X(Twitter)共有ボタンのクリックで適切なURLが生成されることを確認
- [x] Facebook共有ボタンのクリックで適切なURLが生成されることを確認
- [x] カスタムURLを指定した場合の動作確認
- [x] 現在のページURLを使用する場合の動作確認
- [x] ホバー効果とフォーカス効果の動作確認
- [x] ESLintとTypeScriptの型チェックが通ることを確認
- [x] 全テストが正常に通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)