### PR TITLE
CSP設定を追加する

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,4 @@
 ENV=local
 BROWSER_BASE_URL=http://localhost:8080/api
 API_BASE_URL=http://api:8080/api
+IMAGE_SOURCE_URLS=http://localhost,http://minio

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,78 @@
 import { NextConfig } from 'next'
 
+const defaultApiBaseUrl = 'http://localhost:8080/api'
+const apiBaseUrl = process.env.API_BASE_URL ? process.env.API_BASE_URL : defaultApiBaseUrl
+const browserBaseUrl = process.env.BROWSER_BASE_URL ? process.env.BROWSER_BASE_URL : defaultApiBaseUrl
+const domainUrl = process.env.DOMAIN_URL ? process.env.DOMAIN_URL : `http://localhost:${process.env.PORT ? process.env.PORT : '3000'}`
+const isProduction = process.env.NODE_ENV === 'production'
+
+const getOrigin = (url: string): string | undefined => {
+    try {
+        return new URL(url).origin
+    } catch {
+        return undefined
+    }
+}
+
+const unique = (values: string[]): string[] => Array.from(new Set(values))
+
+const apiOrigins = unique([apiBaseUrl, browserBaseUrl].map((url) => getOrigin(url)).filter((origin): origin is string => Boolean(origin)))
+
+const buildContentSecurityPolicy = (): string => {
+    const scriptSources = ["'self'", "'unsafe-inline'", 'https://www.googletagmanager.com', 'https://www.google-analytics.com']
+    const connectSources = ["'self'", ...apiOrigins, 'https://www.google-analytics.com', 'https://region1.google-analytics.com']
+
+    if (!isProduction) {
+        scriptSources.push("'unsafe-eval'")
+        connectSources.push('http://localhost:*', 'ws://localhost:*')
+    }
+
+    const directives = [
+        ['default-src', "'self'"],
+        ['base-uri', "'self'"],
+        ['object-src', "'none'"],
+        ['frame-ancestors', "'none'"],
+        ['form-action', "'self'"],
+        ['script-src', ...scriptSources],
+        ['style-src', "'self'", "'unsafe-inline'"],
+        [
+            'img-src',
+            "'self'",
+            'data:',
+            'blob:',
+            'http://localhost:*',
+            'http://minio:*',
+            'https://tocoriri.com',
+            'https://tku-api-ck57lb-prod.s3.ap-northeast-1.amazonaws.com',
+            'https://www.google-analytics.com',
+            'https://www.googletagmanager.com',
+        ],
+        ['font-src', "'self'", 'data:'],
+        ['connect-src', ...connectSources],
+        ['media-src', "'self'", 'blob:'],
+        ['worker-src', "'self'", 'blob:'],
+        ['manifest-src', "'self'"],
+        ...(isProduction ? [['upgrade-insecure-requests']] : []),
+    ]
+
+    return directives.map((directive) => directive.join(' ')).join('; ')
+}
+
 const nextConfig: NextConfig = {
     output: 'standalone',
+    async headers() {
+        return [
+            {
+                source: '/:path*',
+                headers: [
+                    {
+                        key: 'Content-Security-Policy',
+                        value: buildContentSecurityPolicy(),
+                    },
+                ],
+            },
+        ]
+    },
     sassOptions: {
         prependData: '@use "sass:color"; @use "@/styles/variables.scss" as *; @use "@/styles/mixins.scss" as *; @use "@/styles/layouts.scss" as *;',
     },
@@ -30,9 +101,9 @@ const nextConfig: NextConfig = {
         ],
     },
     env: {
-        API_BASE_URL: process.env.API_BASE_URL ? process.env.API_BASE_URL : 'http://localhost:8080/api',
-        BROWSER_BASE_URL: process.env.BROWSER_BASE_URL ? process.env.BROWSER_BASE_URL : 'http://localhost:8080/api',
-        DOMAIN_URL: process.env.DOMAIN_URL ? process.env.DOMAIN_URL : `http://localhost:${process.env.PORT ? process.env.PORT : '3000'}`,
+        API_BASE_URL: apiBaseUrl,
+        BROWSER_BASE_URL: browserBaseUrl,
+        DOMAIN_URL: domainUrl,
         COOKIE_DOMAIN_URL: process.env.COOKIE_DOMAIN_URL,
         GOOGLE_TAG: process.env.GOOGLE_TAG,
     },

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -12,6 +12,7 @@ const imageSourceUrls = process.env.IMAGE_SOURCE_URLS
           .filter(Boolean)
     : defaultImageSourceUrls
 
+/** URL文字列からCSPに利用するoriginを抽出する。 */
 const getOrigin = (url: string): string | undefined => {
     try {
         return new URL(url, domainUrl).origin
@@ -20,11 +21,13 @@ const getOrigin = (url: string): string | undefined => {
     }
 }
 
+/** 配列の重複値を取り除く。 */
 const unique = (values: string[]): string[] => Array.from(new Set(values))
 
 const apiOrigins = unique([apiBaseUrl, browserBaseUrl].map((url) => getOrigin(url)).filter((origin): origin is string => Boolean(origin)))
 const imageOrigins = unique(imageSourceUrls.map((url) => getOrigin(url)).filter((origin): origin is string => Boolean(origin)))
 
+/** originがHTTPSで配信されるかを判定する。 */
 const isHttpsOrigin = (origin: string): boolean => {
     try {
         return new URL(origin).protocol === 'https:'
@@ -33,6 +36,7 @@ const isHttpsOrigin = (origin: string): boolean => {
     }
 }
 
+/** HTTPS配信だけで構成される本番環境かを判定する。 */
 const shouldUpgradeInsecureRequests = (): boolean => {
     const pageOrigin = getOrigin(domainUrl)
     const subresourceOrigins = unique([...apiOrigins, ...imageOrigins])
@@ -40,6 +44,7 @@ const shouldUpgradeInsecureRequests = (): boolean => {
     return Boolean(pageOrigin) && isProduction && isHttpsOrigin(pageOrigin as string) && subresourceOrigins.every((origin) => isHttpsOrigin(origin))
 }
 
+/** originをCSPのsource表記へ変換する。 */
 const toContentSecurityPolicySource = (origin: string): string => {
     const url = new URL(origin)
 
@@ -62,6 +67,7 @@ const imageRemotePatterns = imageOrigins.map((origin) => {
     }
 })
 
+/** Next.jsレスポンスに設定するCSP文字列を生成する。 */
 const buildContentSecurityPolicy = (): string => {
     const scriptSources = ["'self'", "'unsafe-inline'", 'https://www.googletagmanager.com', 'https://www.google-analytics.com']
     const connectSources = ["'self'", ...apiOrigins, 'https://www.google-analytics.com', 'https://region1.google-analytics.com']

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -5,10 +5,16 @@ const apiBaseUrl = process.env.API_BASE_URL ? process.env.API_BASE_URL : default
 const browserBaseUrl = process.env.BROWSER_BASE_URL ? process.env.BROWSER_BASE_URL : defaultApiBaseUrl
 const domainUrl = process.env.DOMAIN_URL ? process.env.DOMAIN_URL : `http://localhost:${process.env.PORT ? process.env.PORT : '3000'}`
 const isProduction = process.env.NODE_ENV === 'production'
+const defaultImageSourceUrls = ['http://localhost', 'http://minio', domainUrl, 'https://tku-api-ck57lb-prod.s3.ap-northeast-1.amazonaws.com']
+const imageSourceUrls = process.env.IMAGE_SOURCE_URLS
+    ? process.env.IMAGE_SOURCE_URLS.split(',')
+          .map((url) => url.trim())
+          .filter(Boolean)
+    : defaultImageSourceUrls
 
 const getOrigin = (url: string): string | undefined => {
     try {
-        return new URL(url).origin
+        return new URL(url, domainUrl).origin
     } catch {
         return undefined
     }
@@ -17,6 +23,44 @@ const getOrigin = (url: string): string | undefined => {
 const unique = (values: string[]): string[] => Array.from(new Set(values))
 
 const apiOrigins = unique([apiBaseUrl, browserBaseUrl].map((url) => getOrigin(url)).filter((origin): origin is string => Boolean(origin)))
+const imageOrigins = unique(imageSourceUrls.map((url) => getOrigin(url)).filter((origin): origin is string => Boolean(origin)))
+
+const isHttpsOrigin = (origin: string): boolean => {
+    try {
+        return new URL(origin).protocol === 'https:'
+    } catch {
+        return false
+    }
+}
+
+const shouldUpgradeInsecureRequests = (): boolean => {
+    const pageOrigin = getOrigin(domainUrl)
+    const subresourceOrigins = unique([...apiOrigins, ...imageOrigins])
+
+    return Boolean(pageOrigin) && isProduction && isHttpsOrigin(pageOrigin as string) && subresourceOrigins.every((origin) => isHttpsOrigin(origin))
+}
+
+const toContentSecurityPolicySource = (origin: string): string => {
+    const url = new URL(origin)
+
+    if (url.protocol === 'http:' && ['localhost', 'minio'].includes(url.hostname)) {
+        return `${url.protocol}//${url.hostname}:*`
+    }
+
+    return origin
+}
+
+const imageContentSecurityPolicySources = unique(imageOrigins.map((origin) => toContentSecurityPolicySource(origin)))
+
+const imageRemotePatterns = imageOrigins.map((origin) => {
+    const url = new URL(origin)
+
+    return {
+        protocol: url.protocol.replace(':', '') as 'http' | 'https',
+        hostname: url.hostname,
+        pathname: '**',
+    }
+})
 
 const buildContentSecurityPolicy = (): string => {
     const scriptSources = ["'self'", "'unsafe-inline'", 'https://www.googletagmanager.com', 'https://www.google-analytics.com']
@@ -40,10 +84,7 @@ const buildContentSecurityPolicy = (): string => {
             "'self'",
             'data:',
             'blob:',
-            'http://localhost:*',
-            'http://minio:*',
-            'https://tocoriri.com',
-            'https://tku-api-ck57lb-prod.s3.ap-northeast-1.amazonaws.com',
+            ...imageContentSecurityPolicySources,
             'https://www.google-analytics.com',
             'https://www.googletagmanager.com',
         ],
@@ -52,7 +93,7 @@ const buildContentSecurityPolicy = (): string => {
         ['media-src', "'self'", 'blob:'],
         ['worker-src', "'self'", 'blob:'],
         ['manifest-src', "'self'"],
-        ...(isProduction ? [['upgrade-insecure-requests']] : []),
+        ...(shouldUpgradeInsecureRequests() ? [['upgrade-insecure-requests']] : []),
     ]
 
     return directives.map((directive) => directive.join(' ')).join('; ')
@@ -77,28 +118,7 @@ const nextConfig: NextConfig = {
         prependData: '@use "sass:color"; @use "@/styles/variables.scss" as *; @use "@/styles/mixins.scss" as *; @use "@/styles/layouts.scss" as *;',
     },
     images: {
-        remotePatterns: [
-            {
-                protocol: 'http',
-                hostname: 'localhost',
-                pathname: '**',
-            },
-            {
-                protocol: 'http',
-                hostname: 'minio',
-                pathname: '**',
-            },
-            {
-                protocol: 'https',
-                hostname: 'tocoriri.com',
-                pathname: '**',
-            },
-            {
-                protocol: 'https',
-                hostname: 'tku-api-ck57lb-prod.s3.ap-northeast-1.amazonaws.com',
-                pathname: '**',
-            },
-        ],
+        remotePatterns: imageRemotePatterns,
     },
     env: {
         API_BASE_URL: apiBaseUrl,


### PR DESCRIPTION
### 目的/背景

Issue #821 の対応として、現状のフロントエンド構成に合わせた Content Security Policy を追加します。

### 変更点（要点箇条書き）

- `next.config.ts` の `headers()` で全ページに `Content-Security-Policy` ヘッダーを付与
- `API_BASE_URL` / `BROWSER_BASE_URL` から API origin を抽出し、`connect-src` に反映
- Google Analytics、Next.js 開発時の HMR、S3/MinIO/localhost 画像、blob/data URL の利用を考慮した directive を設定
- 既存の環境変数デフォルト値を CSP 生成でも再利用できる形に整理

### 影響範囲（UI/SEO/DB/インフラ）

- UI: 直接の見た目変更なし
- SEO: 直接のメタデータ変更なし
- DB: 影響なし
- インフラ: Next.js レスポンスヘッダーに CSP が追加される

### 検証手順（実行コマンドと観点）

- `cd frontend && pnpm lint`
- `cd frontend && pnpm type-check`
- `cd frontend && pnpm build`
- push フックで `frontend pnpm test-all` と `backend go test ./...` が成功

### リスクとロールバック

- リスク: 本番環境で未把握の外部接続先がある場合、CSP により該当リソースがブロックされる可能性があります。
- ロールバック: `frontend/next.config.ts` の CSP `headers()` 追加分を revert します。

### 参照資料（関連する CLAUDE.md、Issue など）

- Closes #821
- `frontend/CLAUDE.md`
