### PR TITLE
frontend: tsconfig の非推奨 compilerOptions を更新

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "es2015",
         "lib": [
             "dom",
             "dom.iterable",
@@ -22,7 +22,6 @@
                 "name": "next"
             }
         ],
-        "baseUrl": ".",
         "paths": {
             "@/*": [
                 "./src/*"


### PR DESCRIPTION
### 目的/背景

TypeScript 6.0 以降で `target: "es5"` と `baseUrl` が非推奨になり、TypeScript 7.0 で機能しなくなる予定のため、抑制設定ではなく tsconfig の設定自体を移行します。

Closes #997

### 変更点（要点箇条書き）

- `frontend/tsconfig.json` の `target` を `es5` から `es2015` に変更
- 非推奨の `baseUrl` を削除
- `@/* -> ./src/*` の `paths` alias は維持

### 影響範囲（UI/SEO/DB/インフラ）

- UI: なし
- SEO: なし
- DB: なし
- インフラ: なし
- フロントエンドの TypeScript コンパイル設定のみ変更

### 検証手順（実行コマンドと観点）

- `pnpm type-check`
  - TypeScript 設定と `@/` alias 解決が壊れていないことを確認
- `pnpm lint`
  - ESLint が警告ゼロで通ることを確認
- `pnpm test`
  - unit project: 24 files / 188 tests passed
- `pnpm build`
  - Next.js production build が成功することを確認
- pre-push hook
  - frontend `pnpm test-all`: 83 files / 518 tests passed
  - backend Go tests passed

### リスクとロールバック

- リスク: TypeScript の出力 target が ES2015 になるため、ES5 のみの古い実行環境は対象外になります。Next.js 15 / modern browser 前提では問題ない想定です。
- ロールバック: `frontend/tsconfig.json` の `target` と `baseUrl` を元に戻します。

### 参照資料（関連する CLAUDE.md、Issue など）

- Issue: #997
- TypeScript 6.0 release notes: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html
- `frontend/CLAUDE.md`