### PR TITLE
adminの商品一覧にページネーションを追加する

### DIFF
--- a/backend/internal/infra/db/mysql/query/product_query.go
+++ b/backend/internal/infra/db/mysql/query/product_query.go
@@ -72,7 +72,42 @@ func NewProductQueryReader(db *sqlx.DB) *ProductQueryReader {
 	return &ProductQueryReader{db: db}
 }
 
-func (r *ProductQueryReader) ListProducts(ctx context.Context, q usecaseProductQuery.ListProductsQuery) ([]*usecaseProductQuery.Product, error) {
+func (r *ProductQueryReader) ListProducts(ctx context.Context, q usecaseProductQuery.ListProductsQuery) (*usecaseProductQuery.ProductPage, error) {
+	if q.Page <= 0 || q.Limit <= 0 {
+		return &usecaseProductQuery.ProductPage{
+			PageInfo: usecaseProductQuery.OffsetPageInfo{
+				Page:  q.Page,
+				Limit: q.Limit,
+			},
+			Products: []*usecaseProductQuery.Product{},
+		}, nil
+	}
+
+	fromWhereQuery := `
+		FROM product p
+		LEFT JOIN category c ON c.uuid = p.category_uuid AND c.deleted_at IS NULL
+		LEFT JOIN target t ON t.uuid = p.target_uuid AND t.deleted_at IS NULL
+		WHERE p.deleted_at IS NULL
+	`
+	args := make([]any, 0, 2)
+	if q.Mode == "active" {
+		fromWhereQuery += ` AND p.is_active = 1`
+	}
+	if q.Category != "all" {
+		fromWhereQuery += ` AND c.uuid = ?`
+		args = append(args, q.Category)
+	}
+	if q.Target != "all" {
+		fromWhereQuery += ` AND t.uuid = ?`
+		args = append(args, q.Target)
+	}
+
+	var total int
+	if err := r.db.GetContext(ctx, &total, `SELECT COUNT(*) `+fromWhereQuery, args...); err != nil {
+		return nil, err
+	}
+
+	offset := (q.Page - 1) * q.Limit
 	query := `
 		SELECT
 			p.id,
@@ -86,40 +121,35 @@ func (r *ProductQueryReader) ListProducts(ctx context.Context, q usecaseProductQ
 			c.name AS category_name,
 			t.uuid AS target_uuid,
 			t.name AS target_name
-		FROM product p
-		LEFT JOIN category c ON c.uuid = p.category_uuid AND c.deleted_at IS NULL
-		LEFT JOIN target t ON t.uuid = p.target_uuid AND t.deleted_at IS NULL
-		WHERE p.deleted_at IS NULL
-	`
-	args := make([]any, 0, 2)
-	if q.Mode == "active" {
-		query += ` AND p.is_active = 1`
-	}
-	if q.Category != "all" {
-		query += ` AND c.uuid = ?`
-		args = append(args, q.Category)
-	}
-	if q.Target != "all" {
-		query += ` AND t.uuid = ?`
-		args = append(args, q.Target)
-	}
-	query += ` ORDER BY p.created_at DESC, p.id DESC`
+	` + fromWhereQuery + ` ORDER BY p.created_at DESC, p.id DESC LIMIT ? OFFSET ?`
+	listArgs := append(append([]any{}, args...), q.Limit, offset)
 
 	rows := []productBaseRow{}
-	if err := r.db.SelectContext(ctx, &rows, query, args...); err != nil {
+	if err := r.db.SelectContext(ctx, &rows, query, listArgs...); err != nil {
 		return nil, err
 	}
 
 	products := buildProductsFromRows(rows)
-	if len(products) == 0 {
-		return products, nil
+	if len(products) > 0 {
+		if err := r.fillChildren(ctx, products); err != nil {
+			return nil, err
+		}
 	}
 
-	if err := r.fillChildren(ctx, products); err != nil {
-		return nil, err
+	totalPages := 0
+	if total > 0 {
+		totalPages = (total + q.Limit - 1) / q.Limit
 	}
 
-	return products, nil
+	return &usecaseProductQuery.ProductPage{
+		PageInfo: usecaseProductQuery.OffsetPageInfo{
+			Page:       q.Page,
+			Limit:      q.Limit,
+			Total:      total,
+			TotalPages: totalPages,
+		},
+		Products: products,
+	}, nil
 }
 
 func (r *ProductQueryReader) ListCategoryProducts(ctx context.Context, q usecaseProductQuery.ListCategoryProductsQuery) ([]*usecaseProductQuery.CategoryProducts, error) {

--- a/backend/internal/infra/db/mysql/query/product_query.go
+++ b/backend/internal/infra/db/mysql/query/product_query.go
@@ -107,6 +107,22 @@ func (r *ProductQueryReader) ListProducts(ctx context.Context, q usecaseProductQ
 		return nil, err
 	}
 
+	totalPages := 0
+	if total > 0 {
+		totalPages = (total + q.Limit - 1) / q.Limit
+	}
+	if total == 0 || q.Page > totalPages {
+		return &usecaseProductQuery.ProductPage{
+			PageInfo: usecaseProductQuery.OffsetPageInfo{
+				Page:       q.Page,
+				Limit:      q.Limit,
+				Total:      total,
+				TotalPages: totalPages,
+			},
+			Products: []*usecaseProductQuery.Product{},
+		}, nil
+	}
+
 	offset := (q.Page - 1) * q.Limit
 	query := `
 		SELECT
@@ -134,11 +150,6 @@ func (r *ProductQueryReader) ListProducts(ctx context.Context, q usecaseProductQ
 		if err := r.fillChildren(ctx, products); err != nil {
 			return nil, err
 		}
-	}
-
-	totalPages := 0
-	if total > 0 {
-		totalPages = (total + q.Limit - 1) / q.Limit
 	}
 
 	return &usecaseProductQuery.ProductPage{

--- a/backend/internal/interface/http/handler/product.go
+++ b/backend/internal/interface/http/handler/product.go
@@ -35,13 +35,19 @@ func (h *ProductHandler) List(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	products, err := h.productUC.List(r.Context(), q.Mode, q.Category, q.Target)
+	productPage, err := h.productUC.List(r.Context(), usecaseProductQuery.ListProductsQuery{
+		Mode:     q.Mode,
+		Category: q.Category,
+		Limit:    q.Limit,
+		Page:     q.Page,
+		Target:   q.Target,
+	})
 	if err != nil {
 		response.WriteAppError(w, err)
 		return
 	}
 
-	res := presenter.ToProductResponses(products)
+	res := presenter.ToProductListResponse(productPage)
 	response.WriteJSON(w, http.StatusOK, res)
 }
 

--- a/backend/internal/interface/http/handler/product_test.go
+++ b/backend/internal/interface/http/handler/product_test.go
@@ -20,11 +20,13 @@ import (
 
 type stubProductUC struct {
 	listErr    error
-	listRes    []*usecaseProductQuery.Product
+	listRes    *usecaseProductQuery.ProductPage
 	listCalled bool
 	listReq    struct {
 		mode     string
 		category string
+		limit    int
+		page     int
 		target   string
 	}
 
@@ -71,11 +73,13 @@ type stubProductUC struct {
 	}
 }
 
-func (s *stubProductUC) List(ctx context.Context, mode string, category string, target string) ([]*usecaseProductQuery.Product, error) {
+func (s *stubProductUC) List(ctx context.Context, q usecaseProductQuery.ListProductsQuery) (*usecaseProductQuery.ProductPage, error) {
 	s.listCalled = true
-	s.listReq.mode = mode
-	s.listReq.category = category
-	s.listReq.target = target
+	s.listReq.mode = q.Mode
+	s.listReq.category = q.Category
+	s.listReq.limit = q.Limit
+	s.listReq.page = q.Page
+	s.listReq.target = q.Target
 	if s.listErr != nil {
 		return nil, s.listErr
 	}
@@ -170,6 +174,76 @@ func (s *stubProductUC) CreateProductImages(
 
 func (s *stubProductUC) DeleteProductImage(ctx context.Context, productUUID string, productImageUUID string) error {
 	return nil
+}
+
+func TestProductList(t *testing.T) {
+	t.Run("クエリが不正なときバリデーションエラーで失敗する", func(t *testing.T) {
+		uc := &stubProductUC{}
+		h := NewProductHandler(uc)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/product?mode=all&category=all&target=all&page=0&limit=20", nil)
+		rr := httptest.NewRecorder()
+
+		h.List(rr, req)
+
+		if rr.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400, got %d", rr.Code)
+		}
+		if uc.listCalled {
+			t.Fatalf("usecase should not be called on invalid query")
+		}
+	})
+
+	t.Run("有効なクエリを渡したときページ情報つきの商品一覧を返す", func(t *testing.T) {
+		uc := &stubProductUC{
+			listRes: &usecaseProductQuery.ProductPage{
+				PageInfo: usecaseProductQuery.OffsetPageInfo{
+					Page:       2,
+					Limit:      20,
+					Total:      21,
+					TotalPages: 2,
+				},
+				Products: []*usecaseProductQuery.Product{
+					{
+						UUID: "product-uuid",
+						Name: "Product",
+					},
+				},
+			},
+		}
+		h := NewProductHandler(uc)
+
+		req := httptest.NewRequest(http.MethodGet, "/api/product?mode=all&category=all&target=all&page=2&limit=20", nil)
+		rr := httptest.NewRecorder()
+
+		h.List(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d", rr.Code)
+		}
+		if !uc.listCalled {
+			t.Fatalf("usecase should be called")
+		}
+		if uc.listReq.page != 2 || uc.listReq.limit != 20 {
+			t.Fatalf("unexpected pagination args: %+v", uc.listReq)
+		}
+
+		var res map[string]any
+		if err := json.NewDecoder(rr.Body).Decode(&res); err != nil {
+			t.Fatalf("unexpected decode error: %v", err)
+		}
+		pageInfo, ok := res["pageInfo"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected pageInfo object")
+		}
+		if pageInfo["page"] != float64(2) || pageInfo["total"] != float64(21) || pageInfo["totalPages"] != float64(2) {
+			t.Fatalf("unexpected pageInfo: %+v", pageInfo)
+		}
+		products, ok := res["products"].([]any)
+		if !ok || len(products) != 1 {
+			t.Fatalf("unexpected products: %+v", res["products"])
+		}
+	})
 }
 
 func TestProductListByCategory(t *testing.T) {

--- a/backend/internal/interface/http/presenter/product.go
+++ b/backend/internal/interface/http/presenter/product.go
@@ -66,6 +66,25 @@ func ToProductResponses(products []*usecaseProductQuery.Product) []*response.Pro
 	return result
 }
 
+func ToProductListResponse(productPage *usecaseProductQuery.ProductPage) *response.ProductListResponse {
+	if productPage == nil {
+		return &response.ProductListResponse{
+			PageInfo: response.OffsetPageInfoResponse{},
+			Products: []*response.ProductResponse{},
+		}
+	}
+
+	return &response.ProductListResponse{
+		PageInfo: response.OffsetPageInfoResponse{
+			Page:       productPage.PageInfo.Page,
+			Limit:      productPage.PageInfo.Limit,
+			Total:      productPage.PageInfo.Total,
+			TotalPages: productPage.PageInfo.TotalPages,
+		},
+		Products: ToProductResponses(productPage.Products),
+	}
+}
+
 func ToCategoryProductsResponse(categoryProducts *usecaseProductQuery.CategoryProducts) *response.CategoryProductsResponse {
 	if categoryProducts == nil {
 		return &response.CategoryProductsResponse{

--- a/backend/internal/interface/http/request/product.go
+++ b/backend/internal/interface/http/request/product.go
@@ -11,7 +11,9 @@ import (
 
 const (
 	defaultCategoryProductLimit = 4
+	defaultProductLimit         = 20
 	maxCategoryProductLimit     = 20
+	maxProductLimit             = 100
 )
 
 type ProductClassificationRequest struct {
@@ -67,6 +69,8 @@ type UpdateProductRequest struct {
 type ListProductQuery struct {
 	Mode     string
 	Category string
+	Limit    int
+	Page     int
 	Target   string
 }
 
@@ -81,14 +85,32 @@ func ParseListProductQuery(r *http.Request) (ListProductQuery, error) {
 	q := r.URL.Query()
 	mode := strings.TrimSpace(q.Get("mode"))
 	category := strings.TrimSpace(q.Get("category"))
+	limit := defaultProductLimit
+	page := 1
 	target := strings.TrimSpace(q.Get("target"))
+
+	if rawPage := strings.TrimSpace(q.Get("page")); rawPage != "" {
+		parsedPage, err := strconv.Atoi(rawPage)
+		if err != nil || parsedPage <= 0 {
+			return ListProductQuery{}, errors.New("invalid page")
+		}
+		page = parsedPage
+	}
+
+	if rawLimit := strings.TrimSpace(q.Get("limit")); rawLimit != "" {
+		parsedLimit, err := strconv.Atoi(rawLimit)
+		if err != nil || parsedLimit <= 0 || parsedLimit > maxProductLimit {
+			return ListProductQuery{}, errors.New("invalid limit")
+		}
+		limit = parsedLimit
+	}
 
 	switch mode {
 	case usecaseProduct.ListModeAll, usecaseProduct.ListModeActive:
 		if category == "" || target == "" {
 			return ListProductQuery{}, errors.New("invalid query")
 		}
-		return ListProductQuery{Mode: mode, Category: category, Target: target}, nil
+		return ListProductQuery{Mode: mode, Category: category, Limit: limit, Page: page, Target: target}, nil
 	default:
 		return ListProductQuery{}, errors.New("invalid mode")
 	}

--- a/backend/internal/interface/http/response/page_info.go
+++ b/backend/internal/interface/http/response/page_info.go
@@ -4,3 +4,10 @@ type CursorPageInfoResponse struct {
 	HasMore    bool   `json:"hasMore"`
 	NextCursor string `json:"nextCursor"`
 }
+
+type OffsetPageInfoResponse struct {
+	Page       int `json:"page"`
+	Limit      int `json:"limit"`
+	Total      int `json:"total"`
+	TotalPages int `json:"totalPages"`
+}

--- a/backend/internal/interface/http/response/product.go
+++ b/backend/internal/interface/http/response/product.go
@@ -41,6 +41,11 @@ type CreateProductResponse struct {
 	UUID string `json:"uuid"`
 }
 
+type ProductListResponse struct {
+	PageInfo OffsetPageInfoResponse `json:"pageInfo"`
+	Products []*ProductResponse     `json:"products"`
+}
+
 type CategoryProductsResponse struct {
 	Category ProductClassificationResponse `json:"category"`
 	PageInfo CursorPageInfoResponse        `json:"pageInfo"`

--- a/backend/internal/usecase/product/port.go
+++ b/backend/internal/usecase/product/port.go
@@ -13,7 +13,7 @@ const (
 )
 
 type QueryUsecase interface {
-	List(ctx context.Context, mode string, category string, target string) ([]*usecaseProductQuery.Product, error)
+	List(ctx context.Context, q usecaseProductQuery.ListProductsQuery) (*usecaseProductQuery.ProductPage, error)
 	ListByCategory(ctx context.Context, q usecaseProductQuery.ListCategoryProductsQuery) ([]*usecaseProductQuery.CategoryProducts, error)
 	ListCarousel(ctx context.Context) ([]*usecaseProductQuery.CarouselItem, error)
 	Get(ctx context.Context, productUUID string) (*usecaseProductQuery.Product, error)
@@ -50,8 +50,8 @@ func New(queryUC QueryUsecase, commandUC CommandUsecase) *Service {
 	}
 }
 
-func (s *Service) List(ctx context.Context, mode string, category string, target string) ([]*usecaseProductQuery.Product, error) {
-	return s.queryUC.List(ctx, mode, category, target)
+func (s *Service) List(ctx context.Context, q usecaseProductQuery.ListProductsQuery) (*usecaseProductQuery.ProductPage, error) {
+	return s.queryUC.List(ctx, q)
 }
 
 func (s *Service) ListByCategory(ctx context.Context, q usecaseProductQuery.ListCategoryProductsQuery) ([]*usecaseProductQuery.CategoryProducts, error) {

--- a/backend/internal/usecase/product/query/model.go
+++ b/backend/internal/usecase/product/query/model.go
@@ -45,6 +45,18 @@ type PageInfo struct {
 	NextCursor string
 }
 
+type OffsetPageInfo struct {
+	Page       int
+	Limit      int
+	Total      int
+	TotalPages int
+}
+
+type ProductPage struct {
+	PageInfo OffsetPageInfo
+	Products []*Product
+}
+
 type CategoryProducts struct {
 	Category Classification
 	PageInfo PageInfo

--- a/backend/internal/usecase/product/query/reader.go
+++ b/backend/internal/usecase/product/query/reader.go
@@ -5,6 +5,8 @@ import "context"
 type ListProductsQuery struct {
 	Mode     string
 	Category string
+	Limit    int
+	Page     int
 	Target   string
 }
 
@@ -22,7 +24,7 @@ type ListCarouselQuery struct {
 type ExportProductsCSVQuery struct{}
 
 type Reader interface {
-	ListProducts(ctx context.Context, q ListProductsQuery) ([]*Product, error)
+	ListProducts(ctx context.Context, q ListProductsQuery) (*ProductPage, error)
 	ListCategoryProducts(ctx context.Context, q ListCategoryProductsQuery) ([]*CategoryProducts, error)
 	ListCarouselItems(ctx context.Context, q ListCarouselQuery) ([]*CarouselItem, error)
 	GetProductByUUID(ctx context.Context, productUUID string) (*Product, error)

--- a/backend/internal/usecase/product/query/usecase.go
+++ b/backend/internal/usecase/product/query/usecase.go
@@ -19,7 +19,7 @@ const (
 )
 
 type Usecase interface {
-	List(ctx context.Context, mode string, category string, target string) ([]*Product, error)
+	List(ctx context.Context, q ListProductsQuery) (*ProductPage, error)
 	ListByCategory(ctx context.Context, q ListCategoryProductsQuery) ([]*CategoryProducts, error)
 	ListCarousel(ctx context.Context) ([]*CarouselItem, error)
 	Get(ctx context.Context, productUUID string) (*Product, error)
@@ -40,25 +40,34 @@ func New(queryReader Reader, storage usecase.Storage) *Service {
 	}
 }
 
-func (s *Service) List(ctx context.Context, mode string, category string, target string) ([]*Product, error) {
-	if !isValidListMode(mode) || strings.TrimSpace(category) == "" || strings.TrimSpace(target) == "" {
+func (s *Service) List(ctx context.Context, q ListProductsQuery) (*ProductPage, error) {
+	trimmedCategory := strings.TrimSpace(q.Category)
+	trimmedTarget := strings.TrimSpace(q.Target)
+
+	if !isValidListMode(q.Mode) || trimmedCategory == "" || trimmedTarget == "" || q.Page <= 0 || q.Limit <= 0 {
 		return nil, usecase.NewAppError(usecase.ErrInvalidInput)
 	}
 
-	products, err := s.queryReader.ListProducts(ctx, ListProductsQuery{
-		Mode:     mode,
-		Category: category,
-		Target:   target,
+	productPage, err := s.queryReader.ListProducts(ctx, ListProductsQuery{
+		Mode:     q.Mode,
+		Category: trimmedCategory,
+		Limit:    q.Limit,
+		Page:     q.Page,
+		Target:   trimmedTarget,
 	})
 	if err != nil {
 		return nil, usecase.NewAppErrorWithMessage(usecase.ErrInternal, err.Error())
 	}
 
-	if err := s.attachPresignedImageURLs(ctx, products); err != nil {
+	if productPage == nil {
+		return &ProductPage{}, nil
+	}
+
+	if err := s.attachPresignedImageURLs(ctx, productPage.Products); err != nil {
 		return nil, err
 	}
 
-	return products, nil
+	return productPage, nil
 }
 
 func (s *Service) ListByCategory(ctx context.Context, q ListCategoryProductsQuery) ([]*CategoryProducts, error) {

--- a/backend/internal/usecase/product/query/usecase_test.go
+++ b/backend/internal/usecase/product/query/usecase_test.go
@@ -12,8 +12,9 @@ import (
 )
 
 type stubQueryReader struct {
-	listRes            []*Product
+	listRes            *ProductPage
 	listErr            error
+	listQuery          ListProductsQuery
 	listByCatRes       []*CategoryProducts
 	listByCatErr       error
 	listByCatQuery     ListCategoryProductsQuery
@@ -27,7 +28,8 @@ type stubQueryReader struct {
 	exportCSVErr       error
 }
 
-func (s *stubQueryReader) ListProducts(ctx context.Context, q ListProductsQuery) ([]*Product, error) {
+func (s *stubQueryReader) ListProducts(ctx context.Context, q ListProductsQuery) (*ProductPage, error) {
+	s.listQuery = q
 	if s.listErr != nil {
 		return nil, s.listErr
 	}
@@ -93,7 +95,21 @@ func TestListProducts(t *testing.T) {
 	t.Run("modeが不正なときバリデーションエラーで失敗する", func(t *testing.T) {
 		s := &Service{}
 
-		_, err := s.List(context.Background(), "invalid", "all", "all")
+		_, err := s.List(context.Background(), ListProductsQuery{Mode: "invalid", Category: "all", Limit: 20, Page: 1, Target: "all"})
+		if err == nil || !errors.Is(err, usecase.ErrInvalidInput) {
+			t.Fatalf("expected ErrInvalidInput, got %v", err)
+		}
+	})
+
+	t.Run("pageまたはlimitが不正なときバリデーションエラーで失敗する", func(t *testing.T) {
+		s := &Service{}
+
+		_, err := s.List(context.Background(), ListProductsQuery{Mode: "all", Category: "all", Limit: 0, Page: 1, Target: "all"})
+		if err == nil || !errors.Is(err, usecase.ErrInvalidInput) {
+			t.Fatalf("expected ErrInvalidInput, got %v", err)
+		}
+
+		_, err = s.List(context.Background(), ListProductsQuery{Mode: "all", Category: "all", Limit: 20, Page: 0, Target: "all"})
 		if err == nil || !errors.Is(err, usecase.ErrInvalidInput) {
 			t.Fatalf("expected ErrInvalidInput, got %v", err)
 		}
@@ -106,7 +122,7 @@ func TestListProducts(t *testing.T) {
 			},
 		}
 
-		_, err := s.List(context.Background(), "all", "all", "all")
+		_, err := s.List(context.Background(), ListProductsQuery{Mode: "all", Category: "all", Limit: 20, Page: 1, Target: "all"})
 		if err == nil || !errors.Is(err, usecase.ErrInternal) {
 			t.Fatalf("expected ErrInternal, got %v", err)
 		}
@@ -115,11 +131,13 @@ func TestListProducts(t *testing.T) {
 	t.Run("presignに失敗したとき内部エラーを返す", func(t *testing.T) {
 		s := &Service{
 			queryReader: &stubQueryReader{
-				listRes: []*Product{
-					{
-						UUID: "product-uuid",
-						ProductImages: []ProductImage{
-							{Path: "img/product/path.png"},
+				listRes: &ProductPage{
+					Products: []*Product{
+						{
+							UUID: "product-uuid",
+							ProductImages: []ProductImage{
+								{Path: "img/product/path.png"},
+							},
 						},
 					},
 				},
@@ -127,7 +145,7 @@ func TestListProducts(t *testing.T) {
 			storage: &stubStorage{presignErr: errors.New("s3 error")},
 		}
 
-		_, err := s.List(context.Background(), "all", "all", "all")
+		_, err := s.List(context.Background(), ListProductsQuery{Mode: "all", Category: "all", Limit: 20, Page: 1, Target: "all"})
 		if err == nil || !errors.Is(err, usecase.ErrInternal) {
 			t.Fatalf("expected ErrInternal, got %v", err)
 		}
@@ -136,11 +154,19 @@ func TestListProducts(t *testing.T) {
 	t.Run("有効な入力を渡したとき一覧取得に成功しapiPathが設定される", func(t *testing.T) {
 		s := &Service{
 			queryReader: &stubQueryReader{
-				listRes: []*Product{
-					{
-						UUID: "product-uuid",
-						ProductImages: []ProductImage{
-							{Path: "img/product/path.png"},
+				listRes: &ProductPage{
+					PageInfo: OffsetPageInfo{
+						Page:       2,
+						Limit:      20,
+						Total:      21,
+						TotalPages: 2,
+					},
+					Products: []*Product{
+						{
+							UUID: "product-uuid",
+							ProductImages: []ProductImage{
+								{Path: "img/product/path.png"},
+							},
 						},
 					},
 				},
@@ -148,15 +174,22 @@ func TestListProducts(t *testing.T) {
 			storage: &stubStorage{presignURL: "https://signed.example.com/path"},
 		}
 
-		products, err := s.List(context.Background(), "all", "all", "all")
+		productPage, err := s.List(context.Background(), ListProductsQuery{Mode: "all", Category: "all", Limit: 20, Page: 2, Target: "all"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if len(products) != 1 || len(products[0].ProductImages) != 1 {
-			t.Fatalf("unexpected products: %+v", products)
+		if productPage.PageInfo.TotalPages != 2 {
+			t.Fatalf("unexpected page info: %+v", productPage.PageInfo)
 		}
-		if products[0].ProductImages[0].APIPath != "https://signed.example.com/path" {
-			t.Fatalf("unexpected api path: %s", products[0].ProductImages[0].APIPath)
+		if len(productPage.Products) != 1 || len(productPage.Products[0].ProductImages) != 1 {
+			t.Fatalf("unexpected products: %+v", productPage.Products)
+		}
+		if productPage.Products[0].ProductImages[0].APIPath != "https://signed.example.com/path" {
+			t.Fatalf("unexpected api path: %s", productPage.Products[0].ProductImages[0].APIPath)
+		}
+		reader := s.queryReader.(*stubQueryReader)
+		if reader.listQuery.Page != 2 || reader.listQuery.Limit != 20 {
+			t.Fatalf("unexpected query: %+v", reader.listQuery)
 		}
 	})
 }

--- a/frontend/src/__tests__/apis/product.test.ts
+++ b/frontend/src/__tests__/apis/product.test.ts
@@ -278,17 +278,30 @@ describe('product API', () => {
     describe('getProducts', () => {
         it('管理画面用一覧取得はCookie付きでリクエストする', async () => {
             const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-                new Response(JSON.stringify([]), {
-                    headers: {
-                        'Content-Type': 'application/json',
+                new Response(
+                    JSON.stringify({
+                        pageInfo: {
+                            limit: 20,
+                            page: 1,
+                            total: 0,
+                            totalPages: 0,
+                        },
+                        products: [],
+                    }),
+                    {
+                        headers: {
+                            'Content-Type': 'application/json',
+                        },
+                        status: 200,
                     },
-                    status: 200,
-                }),
+                ),
             )
 
             const result = await getProducts({
                 category: 'all',
+                limit: 20,
                 mode: 'all',
+                page: 1,
                 target: 'all',
             })
 
@@ -296,10 +309,20 @@ describe('product API', () => {
             const url = new URL(requestUrl as string)
 
             expect(url.searchParams.get('category')).toBe('all')
+            expect(url.searchParams.get('limit')).toBe('20')
             expect(url.searchParams.get('mode')).toBe('all')
+            expect(url.searchParams.get('page')).toBe('1')
             expect(url.searchParams.get('target')).toBe('all')
             expect(requestInit?.credentials).toBe('include')
-            expect(result).toEqual([])
+            expect(result).toEqual({
+                pageInfo: {
+                    limit: 20,
+                    page: 1,
+                    total: 0,
+                    totalPages: 0,
+                },
+                products: [],
+            })
         })
     })
 

--- a/frontend/src/__tests__/components/pagination.test.tsx
+++ b/frontend/src/__tests__/components/pagination.test.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { Pagination } from '@/components/bases/Pagination'
+
+describe('Pagination', () => {
+    it('ページ番号と省略記号を表示する', () => {
+        render(<Pagination currentPage={5} onPageChange={vi.fn()} totalPages={10} />)
+
+        expect(screen.getByRole('button', { name: '前のページへ' })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: '5ページへ' })).toHaveAttribute('aria-current', 'page')
+        expect(screen.getAllByText('...')).toHaveLength(2)
+        expect(screen.getByRole('button', { name: '次のページへ' })).toBeInTheDocument()
+    })
+
+    it('ページ番号クリックでページ変更を通知する', () => {
+        const handlePageChange = vi.fn()
+        render(<Pagination currentPage={1} onPageChange={handlePageChange} totalPages={3} />)
+
+        fireEvent.click(screen.getByRole('button', { name: '2ページへ' }))
+
+        expect(handlePageChange).toHaveBeenCalledWith(2)
+    })
+
+    it('1ページだけの場合は表示しない', () => {
+        render(<Pagination currentPage={1} onPageChange={vi.fn()} totalPages={1} />)
+
+        expect(screen.queryByRole('navigation', { name: 'ページネーション' })).not.toBeInTheDocument()
+    })
+})

--- a/frontend/src/__tests__/integration/pages/admin-product.test.tsx
+++ b/frontend/src/__tests__/integration/pages/admin-product.test.tsx
@@ -100,6 +100,16 @@ const mockSalesSitesData = [
     { uuid: 'site-2', name: 'minne' },
 ]
 
+const createProductList = (products = mockProductData, pageInfo?: { limit?: number; page?: number; total?: number; totalPages?: number }) => ({
+    pageInfo: {
+        limit: pageInfo?.limit ?? 20,
+        page: pageInfo?.page ?? 1,
+        total: pageInfo?.total ?? products.length,
+        totalPages: pageInfo?.totalPages ?? Math.ceil(products.length / 20),
+    },
+    products,
+})
+
 describe('Admin Product Page Integration Test', () => {
     const defaultProps = {
         categories: mockCategoriesData,
@@ -112,7 +122,7 @@ describe('Admin Product Page Integration Test', () => {
         vi.clearAllMocks()
 
         // デフォルトのモック設定
-        mockGetProducts.mockResolvedValue(mockProductData)
+        mockGetProducts.mockResolvedValue(createProductList(mockProductData))
         mockGetCategories.mockResolvedValue(mockCategoriesData)
         mockGetTargets.mockResolvedValue(mockTargetsData)
         mockGetTags.mockResolvedValue(mockTagsData)
@@ -121,7 +131,7 @@ describe('Admin Product Page Integration Test', () => {
 
     it('管理画面商品管理ページが正常に表示される', async () => {
         // コンポーネントをレンダリング
-        render(<AdminProductTemplate {...defaultProps} initialProducts={mockProductData} />)
+        render(<AdminProductTemplate {...defaultProps} initialProductList={createProductList(mockProductData)} />)
 
         // 初期データが表示されることを確認
         await waitFor(() => {
@@ -148,17 +158,39 @@ describe('Admin Product Page Integration Test', () => {
 
     it('商品が0件の場合の表示', async () => {
         // 空のデータを設定
-        mockGetProducts.mockResolvedValue([])
+        mockGetProducts.mockResolvedValue(createProductList([]))
 
-        render(<AdminProductTemplate {...defaultProps} initialProducts={[]} />)
+        render(<AdminProductTemplate {...defaultProps} initialProductList={createProductList([])} />)
 
         // 初期状態で0件が表示されることを確認
         expect(screen.getByText('0件の商品')).toBeInTheDocument()
         expect(screen.getByText('登録されていません')).toBeInTheDocument()
     })
 
+    it('ページネーションで次ページの商品を取得できる', async () => {
+        const nextPageProducts = [mockProductData[1]]
+        mockGetProducts.mockResolvedValue(createProductList(nextPageProducts, { page: 2, total: 21, totalPages: 2 }))
+
+        render(<AdminProductTemplate {...defaultProps} initialProductList={createProductList([mockProductData[0]], { total: 21, totalPages: 2 })} />)
+
+        fireEvent.click(screen.getByRole('button', { name: '次のページへ' }))
+
+        await waitFor(() => {
+            expect(mockGetProducts).toHaveBeenCalledWith({
+                category: 'all',
+                limit: 20,
+                mode: 'all',
+                page: 2,
+                target: 'all',
+            })
+        })
+        await waitFor(() => {
+            expect(screen.getByText('テスト商品2')).toBeInTheDocument()
+        })
+    })
+
     it('商品追加ボタンをクリックするとダイアログが開く', async () => {
-        render(<AdminProductTemplate {...defaultProps} initialProducts={mockProductData} />)
+        render(<AdminProductTemplate {...defaultProps} initialProductList={createProductList(mockProductData)} />)
 
         await waitFor(() => {
             expect(screen.getByText('追加')).toBeInTheDocument()
@@ -177,7 +209,7 @@ describe('Admin Product Page Integration Test', () => {
     })
 
     it('商品追加ダイアログをキャンセルで閉じられる', async () => {
-        render(<AdminProductTemplate {...defaultProps} initialProducts={mockProductData} />)
+        render(<AdminProductTemplate {...defaultProps} initialProductList={createProductList(mockProductData)} />)
 
         const addButton = await screen.findByText('追加')
         fireEvent.click(addButton)
@@ -192,7 +224,7 @@ describe('Admin Product Page Integration Test', () => {
     })
 
     it('商品編集機能のクリックが正常に動作する', async () => {
-        render(<AdminProductTemplate {...defaultProps} initialProducts={mockProductData} />)
+        render(<AdminProductTemplate {...defaultProps} initialProductList={createProductList(mockProductData)} />)
 
         // 商品カードが表示されるまで待機
         await waitFor(() => {
@@ -211,7 +243,7 @@ describe('Admin Product Page Integration Test', () => {
     it('商品編集で既存画像を削除すると更新payloadから対象画像だけ除外される', async () => {
         mockUpdateProduct.mockResolvedValue(undefined)
 
-        render(<AdminProductTemplate {...defaultProps} initialProducts={mockProductData} />)
+        render(<AdminProductTemplate {...defaultProps} initialProductList={createProductList(mockProductData)} />)
 
         fireEvent.click(await screen.findByText('テスト商品1'))
 
@@ -251,7 +283,7 @@ describe('Admin Product Page Integration Test', () => {
     it('商品削除機能が正常に動作する', async () => {
         mockDeleteProduct.mockResolvedValue(undefined)
 
-        render(<AdminProductTemplate {...defaultProps} initialProducts={mockProductData} />)
+        render(<AdminProductTemplate {...defaultProps} initialProductList={createProductList(mockProductData)} />)
 
         // 商品カードが表示されるまで待機
         await waitFor(() => {
@@ -280,7 +312,7 @@ describe('Admin Product Page Integration Test', () => {
     })
 
     it('削除確認ダイアログでキャンセルできる', async () => {
-        render(<AdminProductTemplate {...defaultProps} initialProducts={mockProductData} />)
+        render(<AdminProductTemplate {...defaultProps} initialProductList={createProductList(mockProductData)} />)
 
         // 商品カードが表示されるまで待機
         await waitFor(() => {
@@ -317,7 +349,7 @@ describe('Admin Product Page Integration Test', () => {
         mockGetProducts.mockRejectedValue(new Error('API Error'))
         mockDeleteProduct.mockResolvedValue(undefined)
 
-        render(<AdminProductTemplate {...defaultProps} initialProducts={mockProductData} />)
+        render(<AdminProductTemplate {...defaultProps} initialProductList={createProductList(mockProductData)} />)
 
         // 初期表示は正常
         await waitFor(() => {
@@ -345,7 +377,7 @@ describe('Admin Product Page Integration Test', () => {
     })
 
     it('新規商品作成が正常に動作する', async () => {
-        render(<AdminProductTemplate {...defaultProps} initialProducts={mockProductData} />)
+        render(<AdminProductTemplate {...defaultProps} initialProductList={createProductList(mockProductData)} />)
 
         await waitFor(() => {
             expect(screen.getByText('追加')).toBeInTheDocument()
@@ -363,7 +395,7 @@ describe('Admin Product Page Integration Test', () => {
     })
 
     it('Creema複製機能が利用できる', async () => {
-        render(<AdminProductTemplate {...defaultProps} initialProducts={mockProductData} />)
+        render(<AdminProductTemplate {...defaultProps} initialProductList={createProductList(mockProductData)} />)
 
         await waitFor(() => {
             expect(screen.getByText('追加')).toBeInTheDocument()
@@ -390,7 +422,7 @@ describe('Admin Product Page Integration Test', () => {
     })
 
     it('データの再取得が正常に動作する', async () => {
-        render(<AdminProductTemplate {...defaultProps} initialProducts={mockProductData} />)
+        render(<AdminProductTemplate {...defaultProps} initialProductList={createProductList(mockProductData)} />)
 
         // 初回データ読み込み完了まで待機
         await waitFor(() => {
@@ -415,7 +447,7 @@ describe('Admin Product Page Integration Test', () => {
                 siteDetails: [],
             },
         ]
-        mockGetProducts.mockResolvedValue(updatedProductData)
+        mockGetProducts.mockResolvedValue(createProductList(updatedProductData))
         mockGetCategories.mockResolvedValue(mockCategoriesData)
         mockGetTargets.mockResolvedValue(mockTargetsData)
         mockGetTags.mockResolvedValue(mockTagsData)
@@ -439,7 +471,7 @@ describe('Admin Product Page Integration Test', () => {
     })
 
     it('商品データの並び順が正しく表示される', async () => {
-        render(<AdminProductTemplate {...defaultProps} initialProducts={mockProductData} />)
+        render(<AdminProductTemplate {...defaultProps} initialProductList={createProductList(mockProductData)} />)
 
         await waitFor(() => {
             expect(screen.getByText('テスト商品1')).toBeInTheDocument()
@@ -453,7 +485,7 @@ describe('Admin Product Page Integration Test', () => {
     })
 
     it('商品の状態（アクティブ/非アクティブ、推奨/非推奨）が正しく表示される', async () => {
-        render(<AdminProductTemplate {...defaultProps} initialProducts={mockProductData} />)
+        render(<AdminProductTemplate {...defaultProps} initialProductList={createProductList(mockProductData)} />)
 
         // 商品データに基づいて状態を確認
         await waitFor(() => {
@@ -466,7 +498,7 @@ describe('Admin Product Page Integration Test', () => {
     })
 
     it('複数の商品を同時に操作できる', async () => {
-        render(<AdminProductTemplate {...defaultProps} initialProducts={mockProductData} />)
+        render(<AdminProductTemplate {...defaultProps} initialProductList={createProductList(mockProductData)} />)
 
         await waitFor(() => {
             expect(screen.getByText('テスト商品1')).toBeInTheDocument()

--- a/frontend/src/__tests__/integration/pages/admin-product.test.tsx
+++ b/frontend/src/__tests__/integration/pages/admin-product.test.tsx
@@ -170,6 +170,7 @@ describe('Admin Product Page Integration Test', () => {
     it('ページネーションで次ページの商品を取得できる', async () => {
         const nextPageProducts = [mockProductData[1]]
         mockGetProducts.mockResolvedValue(createProductList(nextPageProducts, { page: 2, total: 21, totalPages: 2 }))
+        mockGetCategories.mockRejectedValue(new Error('Category API Error'))
 
         render(<AdminProductTemplate {...defaultProps} initialProductList={createProductList([mockProductData[0]], { total: 21, totalPages: 2 })} />)
 
@@ -187,6 +188,10 @@ describe('Admin Product Page Integration Test', () => {
         await waitFor(() => {
             expect(screen.getByText('テスト商品2')).toBeInTheDocument()
         })
+        expect(mockGetCategories).not.toHaveBeenCalled()
+        expect(mockGetTargets).not.toHaveBeenCalled()
+        expect(mockGetTags).not.toHaveBeenCalled()
+        expect(mockGetSalesSiteList).not.toHaveBeenCalled()
     })
 
     it('商品追加ボタンをクリックするとダイアログが開く', async () => {

--- a/frontend/src/__tests__/mocks/handlers.ts
+++ b/frontend/src/__tests__/mocks/handlers.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse } from 'msw'
 
 import { ICreator } from '@/features/creator/type'
-import { IProduct, IProductsByCategory, IThumbnail } from '@/features/product/type'
+import { IProduct, IProductList, IProductsByCategory, IThumbnail } from '@/features/product/type'
 import { ISite } from '@/features/site/type'
 
 const apiBaseUrl = 'http://localhost:8080/api'
@@ -171,6 +171,39 @@ const createProductsByCategoryResponse = (request: Request): IProductsByCategory
     return Object.values(mockCategories).map((currentCategory) => buildCategoryProducts(currentCategory, null))
 }
 
+const createProductListResponse = (request: Request): IProductList => {
+    const url = new URL(request.url)
+    const category = url.searchParams.get('category')
+    const target = url.searchParams.get('target')
+    const page = Number(url.searchParams.get('page') || '1')
+    const limit = Number(url.searchParams.get('limit') || '20')
+    const currentPage = Number.isFinite(page) && page > 0 ? page : 1
+    const pageSize = Number.isFinite(limit) && limit > 0 ? limit : 20
+
+    let filteredProducts = [...mockProducts]
+
+    if (category && category !== 'all') {
+        filteredProducts = filteredProducts.filter((p) => p.category.uuid === category)
+    }
+
+    if (target && target !== 'all') {
+        filteredProducts = filteredProducts.filter((p) => p.target.uuid === target)
+    }
+
+    const startIndex = (currentPage - 1) * pageSize
+    const products = filteredProducts.slice(startIndex, startIndex + pageSize)
+
+    return {
+        pageInfo: {
+            limit: pageSize,
+            page: currentPage,
+            total: filteredProducts.length,
+            totalPages: Math.ceil(filteredProducts.length / pageSize),
+        },
+        products,
+    }
+}
+
 const mockThumbnails: IThumbnail[] = [
     {
         apiPath: '/image/carousel1.jpg',
@@ -220,24 +253,10 @@ export const handlers = [
     http.get(`${apiBaseUrl}/product`, ({ request }) => {
         const url = new URL(request.url)
         const mode = url.searchParams.get('mode')
-        const category = url.searchParams.get('category')
-        const target = url.searchParams.get('target')
 
         // 管理画面用（mode=all）の場合、全商品を返す
         if (mode === 'all') {
-            let filteredProducts = [...mockProducts]
-
-            // カテゴリフィルタ
-            if (category && category !== 'all') {
-                filteredProducts = filteredProducts.filter((p) => p.category.uuid === category)
-            }
-
-            // ターゲットフィルタ
-            if (target && target !== 'all') {
-                filteredProducts = filteredProducts.filter((p) => p.target.uuid === target)
-            }
-
-            return HttpResponse.json(filteredProducts)
+            return HttpResponse.json(createProductListResponse(request))
         }
 
         // 通常の商品一覧（公開中のみ）

--- a/frontend/src/apis/product.ts
+++ b/frontend/src/apis/product.ts
@@ -1,5 +1,5 @@
 import { getApiBaseUrl } from '@/apis/baseUrl'
-import { IProduct, IProductsByCategory, IThumbnail } from '@/features/product/type'
+import { IProduct, IProductList, IProductsByCategory, IThumbnail } from '@/features/product/type'
 import { createAPIHeaders } from '@/utils/cookie'
 import { ApiError } from '@/utils/error'
 import { convertObjectToURLSearchParams } from '@/utils/request'
@@ -13,9 +13,13 @@ export interface IGetProductsByCategoryParams {
 
 export interface IGetProductsParams {
     category: 'all' | string
+    limit?: number
     mode: 'all' | 'active'
+    page?: number
     target: 'all' | string
 }
+
+export const ADMIN_PRODUCT_PAGE_LIMIT = 20
 
 /** カテゴリーごとの商品リストを取得 */
 export const getProductsByCategory = async (params: IGetProductsByCategoryParams): Promise<IProductsByCategory[]> => {
@@ -86,7 +90,7 @@ export interface IProductImageDisplayOrderParams {
 }
 
 /** 商品リストを取得（管理画面用） */
-export const getProducts = async (params: IGetProductsParams): Promise<IProduct[]> => {
+export const getProducts = async (params: IGetProductsParams): Promise<IProductList> => {
     try {
         const query = convertObjectToURLSearchParams(params)
         const headers = await createAPIHeaders()

--- a/frontend/src/app/admin/product/page.tsx
+++ b/frontend/src/app/admin/product/page.tsx
@@ -1,10 +1,11 @@
 import { Metadata } from 'next'
 
 import { getCategories } from '@/apis/category'
-import { getProducts } from '@/apis/product'
+import { ADMIN_PRODUCT_PAGE_LIMIT, getProducts } from '@/apis/product'
 import { getSalesSiteList } from '@/apis/salesSite'
 import { getTags } from '@/apis/tag'
 import { getTargets } from '@/apis/target'
+import { IProductList } from '@/features/product/type'
 
 import { AdminProductTemplate } from './template'
 
@@ -19,11 +20,23 @@ export const metadata: Metadata = {
 }
 
 const AdminProductPage = async () => {
+    const emptyProductList: IProductList = {
+        pageInfo: {
+            limit: ADMIN_PRODUCT_PAGE_LIMIT,
+            page: 1,
+            total: 0,
+            totalPages: 0,
+        },
+        products: [],
+    }
+
     try {
-        const [products, categories, targets, tags, salesSites] = await Promise.all([
+        const [productList, categories, targets, tags, salesSites] = await Promise.all([
             getProducts({
                 mode: 'all',
                 category: 'all',
+                limit: ADMIN_PRODUCT_PAGE_LIMIT,
+                page: 1,
                 target: 'all',
             }),
             getCategories({ mode: 'all' }),
@@ -32,10 +45,10 @@ const AdminProductPage = async () => {
             getSalesSiteList(),
         ])
 
-        return <AdminProductTemplate categories={categories} initialProducts={products} salesSites={salesSites} tags={tags} targets={targets} />
+        return <AdminProductTemplate categories={categories} initialProductList={productList} salesSites={salesSites} tags={tags} targets={targets} />
     } catch (error) {
         console.error('データの取得に失敗しました:', error)
-        return <AdminProductTemplate categories={[]} initialProducts={[]} salesSites={[]} tags={[]} targets={[]} />
+        return <AdminProductTemplate categories={[]} initialProductList={emptyProductList} salesSites={[]} tags={[]} targets={[]} />
     }
 }
 

--- a/frontend/src/app/admin/product/template/index.tsx
+++ b/frontend/src/app/admin/product/template/index.tsx
@@ -59,6 +59,26 @@ export const AdminProductTemplate = ({
     const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState<boolean>(false)
     const [deleteTargetItem, setDeleteTargetItem] = useState<IProduct | null>(null)
 
+    const fetchProducts = async (page: number) => {
+        try {
+            setIsLoading(true)
+            const productList = await getProducts({
+                mode: 'all',
+                category: 'all',
+                limit: ADMIN_PRODUCT_PAGE_LIMIT,
+                page,
+                target: 'all',
+            })
+
+            setProducts(productList.products)
+            setPageInfo(productList.pageInfo)
+        } catch (error) {
+            console.error('商品リストの取得に失敗しました:', error)
+        } finally {
+            setIsLoading(false)
+        }
+    }
+
     const fetchData = async (page: number = pageInfo.page) => {
         try {
             setIsLoading(true)
@@ -280,7 +300,7 @@ export const AdminProductTemplate = ({
     }
 
     const handlePageChange = async (page: number) => {
-        await fetchData(page)
+        await fetchProducts(page)
     }
 
     return (

--- a/frontend/src/app/admin/product/template/index.tsx
+++ b/frontend/src/app/admin/product/template/index.tsx
@@ -5,25 +5,34 @@ import { useState } from 'react'
 import { toast } from 'sonner'
 
 import { getCategories } from '@/apis/category'
-import { createProduct, deleteProduct, duplicateProductFromCreema, getProducts, updateProduct, uploadProductImages } from '@/apis/product'
+import {
+    ADMIN_PRODUCT_PAGE_LIMIT,
+    createProduct,
+    deleteProduct,
+    duplicateProductFromCreema,
+    getProducts,
+    updateProduct,
+    uploadProductImages,
+} from '@/apis/product'
 import { getSalesSiteList } from '@/apis/salesSite'
 import { getTags } from '@/apis/tag'
 import { getTargets } from '@/apis/target'
 import { Button } from '@/components/bases/Button'
 import { Dialog } from '@/components/bases/Dialog'
+import { Pagination } from '@/components/bases/Pagination'
 import { IClassification } from '@/features/classification/type'
 import { ProductCard } from '@/features/product/components/ProductCard'
 import { ProductFormDialog } from '@/features/product/components/ProductFormDialog'
 import { EXISTING_PRODUCT_IMAGE_ID_PREFIX } from '@/features/product/constants'
 import { ICreemaDuplicateForm } from '@/features/product/product/type'
-import { IProduct, IProductForm } from '@/features/product/type'
+import { IProduct, IProductForm, IProductList } from '@/features/product/type'
 import { ISite } from '@/features/site/type'
 
 import styles from './styles.module.scss'
 
 interface Props {
     categories: IClassification[]
-    initialProducts: IProduct[]
+    initialProductList: IProductList
     salesSites: ISite[]
     tags: IClassification[]
     targets: IClassification[]
@@ -31,12 +40,13 @@ interface Props {
 
 export const AdminProductTemplate = ({
     categories: initialCategories,
-    initialProducts,
+    initialProductList,
     salesSites: initialSalesSites,
     tags: initialTags,
     targets: initialTargets,
 }: Props) => {
-    const [products, setProducts] = useState<IProduct[]>(initialProducts)
+    const [products, setProducts] = useState<IProduct[]>(initialProductList.products)
+    const [pageInfo, setPageInfo] = useState(initialProductList.pageInfo)
     const [categories, setCategories] = useState<IClassification[]>(initialCategories)
     const [targets, setTargets] = useState<IClassification[]>(initialTargets)
     const [tags, setTags] = useState<IClassification[]>(initialTags)
@@ -49,13 +59,15 @@ export const AdminProductTemplate = ({
     const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState<boolean>(false)
     const [deleteTargetItem, setDeleteTargetItem] = useState<IProduct | null>(null)
 
-    const fetchData = async () => {
+    const fetchData = async (page: number = pageInfo.page) => {
         try {
             setIsLoading(true)
-            const [fetchedProducts, categoriesData, targetsData, tagsData, salesSitesData] = await Promise.all([
+            const [productList, categoriesData, targetsData, tagsData, salesSitesData] = await Promise.all([
                 getProducts({
                     mode: 'all',
                     category: 'all',
+                    limit: ADMIN_PRODUCT_PAGE_LIMIT,
+                    page,
                     target: 'all',
                 }),
                 getCategories({ mode: 'all' }),
@@ -63,7 +75,8 @@ export const AdminProductTemplate = ({
                 getTags(),
                 getSalesSiteList(),
             ])
-            setProducts(fetchedProducts)
+            setProducts(productList.products)
+            setPageInfo(productList.pageInfo)
             setCategories(categoriesData)
             setTargets(targetsData)
             setTags(tagsData)
@@ -103,7 +116,8 @@ export const AdminProductTemplate = ({
         try {
             await deleteProduct(deleteTargetItem.uuid)
             toast.success(`商品「${deleteTargetItem.name}」を削除しました`)
-            await fetchData()
+            const nextPage = products.length === 1 && pageInfo.page > 1 ? pageInfo.page - 1 : pageInfo.page
+            await fetchData(nextPage)
             handleCloseDeleteDialog()
         } catch (error) {
             console.error('商品の削除に失敗しました:', error)
@@ -234,7 +248,7 @@ export const AdminProductTemplate = ({
                 toast.success(`商品「${data.name}」を追加しました`)
             }
 
-            await fetchData()
+            await fetchData(updateItem ? pageInfo.page : 1)
         } catch (error) {
             console.error('商品の保存に失敗しました:', error)
             const errorMessage = '商品の保存に失敗しました。もう一度お試しください。'
@@ -254,7 +268,7 @@ export const AdminProductTemplate = ({
 
             setIsDialogOpen(false)
             toast.success('Creemaから商品を複製しました')
-            await fetchData()
+            await fetchData(1)
         } catch (error) {
             console.error('Creemaからの商品複製に失敗しました:', error)
             const errorMessage = 'Creemaからの商品複製に失敗しました。もう一度お試しください。'
@@ -265,12 +279,16 @@ export const AdminProductTemplate = ({
         }
     }
 
+    const handlePageChange = async (page: number) => {
+        await fetchData(page)
+    }
+
     return (
         <div className={styles['product-container']}>
             <div className={styles['page-header']}>
                 <h1 className={styles['page-title']}>商品一覧</h1>
                 <div className={styles['header-actions']}>
-                    <div className={styles['product-count']}>{products.length}件の商品</div>
+                    <div className={styles['product-count']}>{pageInfo.total}件の商品</div>
                     <Button onClick={handleCreate}>
                         <div className={styles['add-button-content']}>
                             <Add className={styles['add-icon']} fontSize="small" />
@@ -295,6 +313,7 @@ export const AdminProductTemplate = ({
                         )}
                     </div>
                 )}
+                <Pagination currentPage={pageInfo.page} disabled={isLoading} onPageChange={handlePageChange} totalPages={pageInfo.totalPages} />
             </div>
 
             <ProductFormDialog

--- a/frontend/src/components/bases/Pagination/index.stories.tsx
+++ b/frontend/src/components/bases/Pagination/index.stories.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react'
+
+import { Pagination } from '.'
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+
+const meta: Meta<typeof Pagination> = {
+    component: Pagination,
+    args: {
+        currentPage: 1,
+        disabled: false,
+        siblingCount: 1,
+        totalPages: 10,
+        onPageChange: (page) => console.log('page changed:', page),
+    },
+    argTypes: {
+        currentPage: {
+            control: { type: 'number', min: 1 },
+        },
+        disabled: {
+            control: { type: 'boolean' },
+        },
+        siblingCount: {
+            control: { type: 'number', min: 0, max: 3 },
+        },
+        totalPages: {
+            control: { type: 'number', min: 1 },
+        },
+    },
+}
+
+export default meta
+type Story = StoryObj<typeof Pagination>
+
+export const Default: Story = {}
+
+export const MiddlePage: Story = {
+    args: {
+        currentPage: 5,
+        totalPages: 10,
+    },
+}
+
+export const LastPage: Story = {
+    args: {
+        currentPage: 10,
+        totalPages: 10,
+    },
+}
+
+export const FewPages: Story = {
+    args: {
+        currentPage: 2,
+        totalPages: 4,
+    },
+}
+
+export const Disabled: Story = {
+    args: {
+        currentPage: 3,
+        disabled: true,
+        totalPages: 10,
+    },
+}
+
+export const Interactive: Story = {
+    render: (args) => {
+        const [currentPage, setCurrentPage] = useState(args.currentPage)
+
+        return <Pagination {...args} currentPage={currentPage} onPageChange={setCurrentPage} />
+    },
+}

--- a/frontend/src/components/bases/Pagination/index.tsx
+++ b/frontend/src/components/bases/Pagination/index.tsx
@@ -1,0 +1,103 @@
+import { KeyboardArrowLeft, KeyboardArrowRight } from '@mui/icons-material'
+
+import styles from './styles.module.scss'
+
+type PaginationItem = 'ellipsis' | number
+
+interface Props {
+    currentPage: number
+    disabled?: boolean
+    onPageChange: (_page: number) => void
+    siblingCount?: number
+    totalPages: number
+}
+
+/** 現在ページの周辺と先頭/末尾を残し、長いページ列を省略表示用に整形する。 */
+const createPaginationItems = (currentPage: number, totalPages: number, siblingCount: number): PaginationItem[] => {
+    const visiblePageCount = siblingCount * 2 + 5
+
+    if (totalPages <= visiblePageCount) {
+        return Array.from({ length: totalPages }, (_, index) => index + 1)
+    }
+
+    const firstPage = 1
+    const lastPage = totalPages
+    const leftSibling = Math.max(currentPage - siblingCount, firstPage)
+    const rightSibling = Math.min(currentPage + siblingCount, lastPage)
+    const shouldShowLeftEllipsis = leftSibling > firstPage + 1
+    const shouldShowRightEllipsis = rightSibling < lastPage - 1
+
+    if (!shouldShowLeftEllipsis && shouldShowRightEllipsis) {
+        const leftRange = Array.from({ length: 3 + siblingCount * 2 }, (_, index) => index + 1)
+        return [...leftRange, 'ellipsis', lastPage]
+    }
+
+    if (shouldShowLeftEllipsis && !shouldShowRightEllipsis) {
+        const rightRangeStart = lastPage - (2 + siblingCount * 2)
+        const rightRange = Array.from({ length: lastPage - rightRangeStart + 1 }, (_, index) => rightRangeStart + index)
+        return [firstPage, 'ellipsis', ...rightRange]
+    }
+
+    const middleRange = Array.from({ length: rightSibling - leftSibling + 1 }, (_, index) => leftSibling + index)
+    return [firstPage, 'ellipsis', ...middleRange, 'ellipsis', lastPage]
+}
+
+export const Pagination = ({ currentPage, disabled = false, onPageChange, siblingCount = 1, totalPages }: Props) => {
+    if (totalPages <= 1) return null
+
+    const paginationItems = createPaginationItems(currentPage, totalPages, siblingCount)
+    const canGoPrevious = currentPage > 1
+    const canGoNext = currentPage < totalPages
+
+    const handlePageChange = (page: number) => {
+        if (disabled || page === currentPage || page < 1 || page > totalPages) return
+
+        onPageChange(page)
+    }
+
+    return (
+        <nav aria-label="ページネーション" className={styles['container']}>
+            <button
+                aria-label="前のページへ"
+                className={styles['nav-button']}
+                disabled={disabled || !canGoPrevious}
+                onClick={() => handlePageChange(currentPage - 1)}
+                type="button"
+            >
+                <KeyboardArrowLeft fontSize="small" />
+                <span>前へ</span>
+            </button>
+            <div className={styles['page-list']}>
+                {paginationItems.map((item, index) =>
+                    item === 'ellipsis' ? (
+                        <span aria-hidden="true" className={styles['ellipsis']} key={`ellipsis-${index}`}>
+                            ...
+                        </span>
+                    ) : (
+                        <button
+                            aria-current={item === currentPage ? 'page' : undefined}
+                            aria-label={`${item}ページへ`}
+                            className={`${styles['page-button']} ${item === currentPage ? styles['active'] : ''}`}
+                            disabled={disabled || item === currentPage}
+                            key={item}
+                            onClick={() => handlePageChange(item)}
+                            type="button"
+                        >
+                            {item}
+                        </button>
+                    ),
+                )}
+            </div>
+            <button
+                aria-label="次のページへ"
+                className={styles['nav-button']}
+                disabled={disabled || !canGoNext}
+                onClick={() => handlePageChange(currentPage + 1)}
+                type="button"
+            >
+                <span>次へ</span>
+                <KeyboardArrowRight fontSize="small" />
+            </button>
+        </nav>
+    )
+}

--- a/frontend/src/components/bases/Pagination/styles.module.scss
+++ b/frontend/src/components/bases/Pagination/styles.module.scss
@@ -1,0 +1,93 @@
+.container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 16px 0;
+}
+
+.page-list {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.nav-button,
+.page-button {
+    border: 1px solid #e1e5e9;
+    background-color: $primary-bg-color;
+    color: $title-primary-color;
+    cursor: pointer;
+    transition: $transition;
+
+    &:hover:not(:disabled) {
+        border-color: $primary;
+        color: $primary;
+    }
+
+    &:focus-visible {
+        outline: 2px solid rgba($primary, 0.5);
+        outline-offset: 2px;
+    }
+
+    &:disabled {
+        cursor: not-allowed;
+        opacity: 0.5;
+    }
+}
+
+.nav-button {
+    min-width: 80px;
+    min-height: 36px;
+    padding: 0 12px;
+    border-radius: 4px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    font-size: $font-sm-md;
+}
+
+.page-button {
+    width: 36px;
+    height: 36px;
+    border-radius: 4px;
+    font-size: $font-sm-md;
+
+    &.active {
+        border-color: $primary;
+        background-color: $primary;
+        color: $primary-bg-color;
+        opacity: 1;
+    }
+}
+
+.ellipsis {
+    width: 32px;
+    height: 36px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: $text-color;
+}
+
+@include media('sm') {
+    .container {
+        gap: 6px;
+    }
+
+    .nav-button {
+        min-width: 40px;
+        padding: 0 8px;
+
+        span {
+            display: none;
+        }
+    }
+
+    .page-button,
+    .ellipsis {
+        width: 32px;
+        height: 32px;
+    }
+}

--- a/frontend/src/features/product/type.ts
+++ b/frontend/src/features/product/type.ts
@@ -35,6 +35,18 @@ export interface IProductsByCategoryPageInfo {
     nextCursor: string
 }
 
+export interface IProductListPageInfo {
+    limit: number
+    page: number
+    total: number
+    totalPages: number
+}
+
+export interface IProductList {
+    pageInfo: IProductListPageInfo
+    products: IProduct[]
+}
+
 export interface IProductsByCategory {
     category: IClassification
     pageInfo: IProductsByCategoryPageInfo


### PR DESCRIPTION
### 目的/背景

adminの商品一覧画面で商品カードが全件表示されており、商品数が増えると視認性と表示負荷が悪化するため、ページネーションで表示件数を制限します。

Closes #998

### 変更点（要点箇条書き）

- admin向けの商品一覧APIに `page` / `limit` を追加し、`total` / `totalPages` を含むレスポンスに変更
- 商品一覧のSQLに `LIMIT` / `OFFSET` と総件数取得を追加
- admin商品一覧画面で1ページ20件表示にし、ページネーションUIを追加
- 作成・更新・削除・Creema複製後の再取得時にページ状態が破綻しないよう調整
- ページネーションコンポーネント、Storybook、関連テストを追加/更新

### 影響範囲（UI/SEO/DB/インフラ）

- UI: `/admin/product` の商品一覧にページネーションが追加されます。20件以下の場合はページネーションを表示しません。
- SEO: admin配下のため影響なし。
- DB: スキーマ変更なし。商品一覧取得時に総件数取得クエリと `LIMIT/OFFSET` が追加されます。
- インフラ: 影響なし。

### 検証手順（実行コマンドと観点）

- `go test ./...`
- `pnpm vitest --project=unit src/__tests__/components/pagination.test.tsx src/__tests__/apis/product.test.ts src/__tests__/integration/pages/admin-product.test.tsx`
- pre-push hook: `pnpm test-all` と backend test が成功
- ローカル `/admin/product` で、20件以下のデータではページネーションが非表示になることを確認

### リスクとロールバック

- APIレスポンス形状が商品配列から `{ products, pageInfo }` に変わるため、admin商品一覧以外の `getProducts` 呼び出しがないことを前提にしています。
- 問題があれば、このPRの変更を revert することで従来の全件取得・全件表示に戻せます。

### 参照資料（関連する CLAUDE.md、Issue など）

- #998
- `frontend/CLAUDE.md`
- `backend/CLAUDE.md`
