### PR TITLE
GitHub Issue/PR ワークフロー用 skill を追加

### DIFF
--- a/.codex/skills/github-issue-pr-workflow/SKILL.md
+++ b/.codex/skills/github-issue-pr-workflow/SKILL.md
@@ -63,13 +63,15 @@ When a change spans frontend/backend/infra, validate each touched area enough to
 ```markdown
 ## 目的/背景
 
-## 変更点
+## 変更点（要点箇条書き）
 
-## 影響範囲
+## 影響範囲（UI/SEO/DB/インフラ）
 
-## 検証
+## 検証手順（実行コマンドと観点）
 
 ## リスクとロールバック
+
+## 参照資料（関連する CLAUDE.md 節、Issue など）
 
 Closes #<issue-number>
 ```
@@ -91,7 +93,7 @@ When the user says reviews are available, or asks Codex to continue after review
 6. Commit and push the updates.
 7. Reply to resolved review threads when the tool surface supports it.
 
-For detailed triage guidance, read `references/review-response.md` only when review feedback exists.
+For detailed triage guidance, read `.codex/skills/github-issue-pr-workflow/references/review-response.md` only when review feedback exists.
 
 ## Tooling Patterns
 

--- a/.codex/skills/github-issue-pr-workflow/SKILL.md
+++ b/.codex/skills/github-issue-pr-workflow/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: github-issue-pr-workflow
+description: Use this skill when the user asks Codex to handle a repository task end-to-end through GitHub: create an issue from the request, create or switch to a branch, implement the change, open a pull request with an appropriate Japanese description, wait for or fetch PR review feedback, decide a response plan, apply fixes, and push updates.
+---
+
+# GitHub Issue PR Workflow
+
+## Overview
+
+This skill runs a full GitHub-driven development loop for this repository: request intake, issue creation, branch work, implementation, PR creation, review handling, and follow-up pushes.
+
+Use it when the user wants work managed through GitHub rather than only local edits.
+
+## Required Context
+
+- Read `AGENTS.md` and the relevant `CLAUDE.md` files before editing.
+- Inspect `git status --short` before changes. Do not overwrite unrelated user changes.
+- Prefer GitHub MCP tools when available. Otherwise use `gh` CLI. If neither is authenticated, stop after local preparation and explain the blocker.
+- Use Japanese for user-facing updates, issue bodies, PR descriptions, and commit messages unless the repository convention says otherwise.
+
+## Workflow
+
+### 1. Intake and Issue
+
+1. Convert the user's request into a concise issue title and body.
+2. Search existing open issues first to avoid duplicates.
+3. Create a GitHub issue only when no suitable issue already exists.
+4. Include:
+   - Background or goal
+   - Requested behavior
+   - Scope and exclusions when known
+   - Validation expectations
+
+If the request is ambiguous enough that implementation would be risky, ask one concise clarification before creating the issue.
+
+### 2. Branch
+
+1. Sync the default branch using the repository's normal flow.
+2. Create a branch named from the issue, for example `issue-123-fix-product-image-upload`.
+3. If an appropriate branch already exists, switch to it after checking it is not carrying unrelated work.
+
+Do not use destructive git commands. Avoid force-push unless the user explicitly approves it.
+
+### 3. Implement
+
+1. Make the smallest coherent change that satisfies the issue.
+2. Follow the repository guides:
+   - Root: `AGENTS.md`, `CLAUDE.md`
+   - Frontend: `frontend/CLAUDE.md`
+   - Backend: `backend/CLAUDE.md`
+   - Infra: `infra/CLAUDE.md`
+3. Keep commits focused. Do not include `.gitignore` targets, secrets, build artifacts, or local editor settings.
+4. Run targeted tests, lint, build, or type checks proportional to the change.
+
+When a change spans frontend/backend/infra, validate each touched area enough to catch contract errors.
+
+### 4. Pull Request
+
+1. Push the branch.
+2. Create a PR linked to the issue.
+3. Write the PR body in the repository's expected style. If no template exists, use:
+
+```markdown
+## 目的/背景
+
+## 変更点
+
+## 影響範囲
+
+## 検証
+
+## リスクとロールバック
+
+Closes #<issue-number>
+```
+
+4. Include exact validation commands and results. If a check could not be run, say why.
+
+### 5. Review Handling
+
+When the user says reviews are available, or asks Codex to continue after review:
+
+1. Fetch PR review comments, requested changes, unresolved threads, and CI status.
+2. Read each comment in context before editing.
+3. Decide and state a short response plan:
+   - Fix now
+   - Explain or push back with evidence
+   - Ask the reviewer for clarification
+4. Apply accepted fixes locally.
+5. Re-run relevant validation.
+6. Commit and push the updates.
+7. Reply to resolved review threads when the tool surface supports it.
+
+For detailed triage guidance, read `references/review-response.md` only when review feedback exists.
+
+## Tooling Patterns
+
+With GitHub MCP, use repository-aware tools for issue search/creation, branch/PR operations, review reading, and review replies.
+
+With `gh` CLI, typical commands are:
+
+```bash
+gh issue list --search "<keywords> state:open"
+gh issue create --title "<title>" --body "<body>"
+git switch -c issue-123-short-slug
+git push -u origin issue-123-short-slug
+gh pr create --fill --body-file <file>
+gh pr view --comments
+gh pr checks
+```
+
+Keep temporary PR body files outside committed changes or remove them before finishing.
+
+## Done Criteria
+
+- Issue exists and is linked from the PR.
+- Branch is pushed.
+- Implementation is complete and scoped.
+- PR description explains purpose, changes, impact, validation, and risk.
+- Review feedback, if present, is either addressed, answered, or explicitly blocked on clarification.
+- Final user update includes issue/PR numbers or URLs, validation results, and any remaining risks.

--- a/.codex/skills/github-issue-pr-workflow/agents/openai.yaml
+++ b/.codex/skills/github-issue-pr-workflow/agents/openai.yaml
@@ -1,0 +1,15 @@
+interface:
+  display_name: "GitHub Issue PR Workflow"
+  short_description: "Issue作成からPRレビュー対応まで一貫して進行"
+  default_prompt: "Use $github-issue-pr-workflow to create an issue, implement the requested change, open a PR, and address review feedback."
+
+dependencies:
+  tools:
+    - type: "mcp"
+      value: "github"
+      description: "GitHub MCP server for issues, branches, pull requests, reviews, and comments."
+      transport: "streamable_http"
+      url: "https://api.githubcopilot.com/mcp/"
+
+policy:
+  allow_implicit_invocation: true

--- a/.codex/skills/github-issue-pr-workflow/references/review-response.md
+++ b/.codex/skills/github-issue-pr-workflow/references/review-response.md
@@ -1,0 +1,37 @@
+# Review Response Guidance
+
+Use this reference only after PR review feedback exists.
+
+## Triage
+
+- Separate blocking requested changes from optional suggestions.
+- Group duplicate comments before editing.
+- Prefer code changes when the reviewer points out a concrete defect, failing test, unclear API, accessibility issue, security risk, or maintainability problem.
+- Prefer explanation when the comment is based on a mistaken assumption and the current code is correct. Include evidence from code, tests, docs, or product requirements.
+- Ask a follow-up question when the requested behavior conflicts with the issue scope or would introduce a larger design decision.
+
+## Response Plan Format
+
+Keep the plan short:
+
+```markdown
+対応方針:
+- <comment summary>: 修正します。
+- <comment summary>: 既存仕様と照合し、PR上で説明します。
+- <comment summary>: 追加確認が必要なため質問します。
+```
+
+## Applying Fixes
+
+- Read the surrounding code before changing anything.
+- Preserve unrelated user changes in the worktree.
+- Keep each commit focused on the review response.
+- Add or adjust tests when the review identifies behavior that should not regress.
+- Re-run the smallest reliable validation set, then broaden it if shared behavior changed.
+
+## Replying
+
+- Be concise and specific.
+- Mention the commit or change that addresses the comment when possible.
+- If not changing code, explain why and reference the relevant requirement or existing behavior.
+- Do not mark a thread resolved unless the requested action is complete or the reviewer has accepted the explanation.

--- a/frontend/src/app/admin/product/template/styles.module.scss
+++ b/frontend/src/app/admin/product/template/styles.module.scss
@@ -36,10 +36,19 @@
 }
 
 .loading {
-    text-align: center;
-    padding: 60px 20px;
+    min-height: 420px;
+    padding: 16px;
+    box-sizing: border-box;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     color: $text-color;
     font-size: $font-normal;
+    text-align: center;
+}
+
+.product-list {
+    min-height: 420px;
 }
 
 .empty-message {


### PR DESCRIPTION
### 目的/背景

Codex に依頼した作業を GitHub Issue/PR ベースで一貫して進められるように、Issue 作成、ブランチ切替、実装、PR 作成、レビュー対応までを扱う skill を追加します。

Closes #1004

### 変更点（要点箇条書き）

- `.codex/skills/github-issue-pr-workflow/SKILL.md` を追加し、Issue 作成から PR レビュー対応までのワークフローを定義
- レビューコメントの triage / 対応方針 / 返信観点を `references/review-response.md` に分離
- `agents/openai.yaml` を追加し、UI 表示名、説明、GitHub MCP 依存情報を定義

### 影響範囲（UI/SEO/DB/インフラ）

- UI: 影響なし
- SEO: 影響なし
- DB: 影響なし
- インフラ: 影響なし
- Codex skill: `.codex/skills/github-issue-pr-workflow/` を追加

### 検証手順（実行コマンドと観点）

- `ruby -e 'require "yaml"; YAML.load_file(".codex/skills/github-issue-pr-workflow/agents/openai.yaml"); puts "openai.yaml ok"'`\n  - `openai.yaml` が YAML として解釈できることを確認\n- `python3 - <<'PY' ... PY`\n  - `SKILL.md` の frontmatter、必須ファイル存在、TODO 残りなしを確認\n- `python3 /Users/shunta/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/github-issue-pr-workflow`\n  - ローカル環境に `PyYAML` がなく `ModuleNotFoundError: No module named 'yaml'` で未実行\n- commit hook: `frontend` の `eslint --max-warnings=0 .` と `next typegen && tsc --noEmit` が成功\n- push hook: `frontend` の `vitest --run --reporter=verbose` が成功（85 files / 529 tests）\n- push hook: `backend` の `go test ./...` 相当が成功\n\n### リスクとロールバック\n\n- リスク: Codex の skill 配置として `.codex/skills/` を採用しているため、別の配置規約がある場合は移動が必要になる可能性があります。\n- ロールバック: `.codex/skills/github-issue-pr-workflow/` を削除すれば戻せます。\n\n### 参照資料（関連する CLAUDE.md、Issue など）\n\n- `AGENTS.md`\n- `CLAUDE.md`\n- #1004\n