### PR TITLE
GitHub Actions OIDC で OpenTofu plan を実行できるようにする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,36 @@ jobs:
         run: tofu -chdir=bootstrap init -backend=false
       - name: Validate bootstrap configuration
         run: tofu -chdir=bootstrap validate
+
+  opentofu-plan:
+    if: github.event.pull_request.head.repo.full_name == github.repository && vars.AWS_PLAN_ROLE_ARN != '' && vars.TOFU_STATE_BUCKET != ''
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./infra/opentofu
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - uses: opentofu/setup-opentofu@9d84900f3238fab8cd84ce47d658d25dd008be2f # v1
+        with:
+          tofu_version: "1.12.0"
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
+        with:
+          aws-region: ap-northeast-1
+          role-session-name: tku-opentofu-plan-${{ github.event.pull_request.number }}
+          role-to-assume: ${{ vars.AWS_PLAN_ROLE_ARN }}
+      - name: Initialize remote state
+        run: |
+          tofu init -reconfigure \
+            -backend-config="bucket=${{ vars.TOFU_STATE_BUCKET }}" \
+            -backend-config="key=tku/production/terraform.tfstate" \
+            -backend-config="region=ap-northeast-1" \
+            -backend-config="encrypt=true" \
+            -backend-config="use_lockfile=true"
+      - name: Plan production infrastructure
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: tofu plan -no-color -var-file=production.tfvars.example

--- a/infra/opentofu/README.md
+++ b/infra/opentofu/README.md
@@ -58,4 +58,16 @@ Railwayのbuild/deploy設定は、現在のDashboard設定を確認してから 
 
 ## CI
 
-PRでは `fmt` と `validate` だけを実行する。認証情報を必要とする `plan` と `apply` は、AWS OIDCとRailway API Tokenの権限・State分離・import完了後に別ワークフローで有効化する。
+PRでは `fmt` と `validate` を実行する。GitHub Actions の設定完了後は、同一リポジトリからのPRで `plan` も実行する。`apply` は別タスクで有効化する。
+
+同一リポジトリから作成されたPRでは、`opentofu-plan` ジョブも実行する。このジョブは GitHub Actions OIDC で `tku-github-actions-opentofu-plan` Role を引き受け、production State の読み取りと lock file の操作、および管理対象 AWS リソースの読み取りだけを許可する。`tofu apply` 権限は付与しない。
+
+有効化前に、bootstrap を適用して次の GitHub Actions 設定を登録する。
+
+- Variable `AWS_PLAN_ROLE_ARN`: `tofu -chdir=infra/opentofu/bootstrap output -raw github_actions_opentofu_plan_role_arn` の出力値
+- Variable `TOFU_STATE_BUCKET`: OpenTofu State バケット名
+- Secret `RAILWAY_TOKEN`: Railway Provider 用 Workspace API token
+
+外部 fork のPRではこのジョブを実行しない。`pull_request_target` は使用しないため、外部 fork に Secrets を渡すことはない。
+
+`AWS_PLAN_ROLE_ARN` または `TOFU_STATE_BUCKET` が未設定の間は、`opentofu-plan` ジョブをスキップする。Role の作成と GitHub Actions 設定が完了してから有効になるため、bootstrap 用の変更を含む最初のPRで認証エラーは発生しない。

--- a/infra/opentofu/README.md
+++ b/infra/opentofu/README.md
@@ -21,6 +21,14 @@ tofu init -backend=false
 tofu apply -var='state_bucket_name=<globally-unique-name>'
 ```
 
+対象 AWS アカウントに GitHub Actions 用 OIDC Provider が既に存在する場合は、bootstrap の `apply` 前に既存リソースをStateへ取り込む。同一アカウント内で `https://token.actions.githubusercontent.com` の OIDC Provider は重複作成できない。
+
+```bash
+cd infra/opentofu/bootstrap
+tofu import aws_iam_openid_connect_provider.github_actions <既存OIDC ProviderのARN>
+tofu plan -var='state_bucket_name=<globally-unique-name>'
+```
+
 作成後は、`bootstrap/backend.hcl.example` を参照してリポジトリ外に bootstrap 用 `backend.hcl` を作成し、ローカルStateをS3へ移行する。
 
 ```bash

--- a/infra/opentofu/bootstrap/github-actions-oidc.tf
+++ b/infra/opentofu/bootstrap/github-actions-oidc.tf
@@ -1,0 +1,128 @@
+resource "aws_iam_openid_connect_provider" "github_actions" {
+  url = "https://token.actions.githubusercontent.com"
+
+  client_id_list = ["sts.amazonaws.com"]
+}
+
+data "aws_iam_policy_document" "github_actions_plan_assume_role" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:tokushun109/tku:pull_request"]
+    }
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github_actions.arn]
+    }
+  }
+}
+
+resource "aws_iam_role" "github_actions_opentofu_plan" {
+  name               = "tku-github-actions-opentofu-plan"
+  assume_role_policy = data.aws_iam_policy_document.github_actions_plan_assume_role.json
+}
+
+data "aws_iam_policy_document" "github_actions_opentofu_plan" {
+  statement {
+    sid = "ListOpenTofuProductionState"
+
+    actions = ["s3:ListBucket"]
+
+    resources = [aws_s3_bucket.state.arn]
+
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values = [
+        "tku/production/terraform.tfstate",
+        "tku/production/terraform.tfstate.tflock",
+      ]
+    }
+  }
+
+  statement {
+    sid = "ReadOpenTofuProductionState"
+
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+    ]
+
+    resources = ["${aws_s3_bucket.state.arn}/tku/production/terraform.tfstate"]
+  }
+
+  statement {
+    sid = "LockOpenTofuProductionState"
+
+    actions = [
+      "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:PutObject",
+    ]
+
+    resources = ["${aws_s3_bucket.state.arn}/tku/production/terraform.tfstate.tflock"]
+  }
+
+  statement {
+    sid = "ReadManagedS3Buckets"
+
+    actions = [
+      "s3:GetBucketAcl",
+      "s3:GetBucketEncryption",
+      "s3:GetBucketLocation",
+      "s3:GetBucketOwnershipControls",
+      "s3:GetBucketPolicy",
+      "s3:GetBucketPolicyStatus",
+      "s3:GetBucketPublicAccessBlock",
+      "s3:GetBucketTagging",
+      "s3:GetBucketVersioning",
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "arn:aws:s3:::tku-api-ck57lb-prod",
+      "arn:aws:s3:::tku-health-check-lambda-archive-bucket",
+      "arn:aws:s3:::tku-warmup-lambda-archive-bucket",
+    ]
+  }
+
+  statement {
+    sid = "ReadManagedInfrastructure"
+
+    actions = [
+      "amplify:GetApp",
+      "amplify:GetBranch",
+      "amplify:GetDomainAssociation",
+      "amplify:ListTagsForResource",
+      "events:DescribeRule",
+      "events:ListTargetsByRule",
+      "events:ListTagsForResource",
+      "iam:GetRole",
+      "iam:GetRolePolicy",
+      "iam:ListAttachedRolePolicies",
+      "iam:ListRolePolicies",
+      "iam:ListRoleTags",
+      "lambda:GetFunction",
+      "lambda:GetPolicy",
+      "lambda:ListTags",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "github_actions_opentofu_plan" {
+  name   = "tku-github-actions-opentofu-plan"
+  role   = aws_iam_role.github_actions_opentofu_plan.id
+  policy = data.aws_iam_policy_document.github_actions_opentofu_plan.json
+}

--- a/infra/opentofu/bootstrap/github-actions-oidc.tf
+++ b/infra/opentofu/bootstrap/github-actions-oidc.tf
@@ -44,8 +44,8 @@ data "aws_iam_policy_document" "github_actions_opentofu_plan" {
       test     = "StringLike"
       variable = "s3:prefix"
       values = [
-        "tku/production/terraform.tfstate",
-        "tku/production/terraform.tfstate.tflock",
+        "tku/production/",
+        "tku/production/terraform.tfstate*",
       ]
     }
   }
@@ -78,7 +78,6 @@ data "aws_iam_policy_document" "github_actions_opentofu_plan" {
 
     actions = [
       "s3:GetBucketAcl",
-      "s3:GetBucketEncryption",
       "s3:GetBucketLocation",
       "s3:GetBucketOwnershipControls",
       "s3:GetBucketPolicy",
@@ -86,6 +85,7 @@ data "aws_iam_policy_document" "github_actions_opentofu_plan" {
       "s3:GetBucketPublicAccessBlock",
       "s3:GetBucketTagging",
       "s3:GetBucketVersioning",
+      "s3:GetEncryptionConfiguration",
       "s3:ListBucket",
     ]
 

--- a/infra/opentofu/bootstrap/outputs.tf
+++ b/infra/opentofu/bootstrap/outputs.tf
@@ -2,3 +2,8 @@ output "state_bucket_name" {
   description = "Use this value in each environment's S3 backend configuration."
   value       = aws_s3_bucket.state.bucket
 }
+
+output "github_actions_opentofu_plan_role_arn" {
+  description = "Set this ARN as the AWS_PLAN_ROLE_ARN GitHub Actions variable."
+  value       = aws_iam_role.github_actions_opentofu_plan.arn
+}


### PR DESCRIPTION
## 目的/背景

GitHub Actions から AWS アクセスキーを使わずに、PR 上で OpenTofu の production `plan` を実行できるようにします。

## 変更点（要点箇条書き）

- bootstrap に GitHub Actions OIDC Provider と `tku-github-actions-opentofu-plan` Role を追加
- Role の信頼条件を `tokushun109/tku` の `pull_request` に限定
- State の読み取り・lock file 操作と、管理対象インフラの読み取りだけを許可
- 同一リポジトリの PR に限定した `opentofu-plan` CI ジョブを追加
- OIDC Role ARN、State バケット、Railway token の設定手順を追記

## 影響範囲（UI/SEO/DB/インフラ）

- インフラ: IAM OIDC Provider / Role / inline policy と GitHub Actions CI
- UI・SEO・DB: 影響なし

## 検証手順（実行コマンドと観点）

- `tofu -chdir=infra/opentofu fmt -check -recursive`
- `tofu -chdir=infra/opentofu/bootstrap init -backend=false`
- `tofu -chdir=infra/opentofu/bootstrap validate`
- `tofu -chdir=infra/opentofu init -backend=false`
- `tofu -chdir=infra/opentofu validate`
- Ruby YAML parser による `.github/workflows/ci.yml` の構文確認
- push hook の frontend / backend 全テスト

`tofu plan` は OIDC Role の apply と GitHub Variables / Secret の登録後に、PR で確認します。

## リスクとロールバック

- bootstrap apply は IAM を変更するため、plan をレビューしてから実行します。
- Role は apply 権限を持たず、State の lock file 以外を変更できません。
- 問題時は CI ジョブの削除と OIDC Role / inline policy の削除で戻せます。

## 参照資料（関連する CLAUDE.md、Issue など）

- `infra/CLAUDE.md`
- `specs/INFRA_NEXT_STEPS.md`
- Closes #1009